### PR TITLE
fix(store): skip initializing StreamMetricsManager when exporter disabled

### DIFF
--- a/broker/src/main/java/com/automq/rocketmq/broker/MetricsExporter.java
+++ b/broker/src/main/java/com/automq/rocketmq/broker/MetricsExporter.java
@@ -243,7 +243,10 @@ public class MetricsExporter implements Lifecycle {
 
     @Override
     public void start() {
-        initDynamicMetrics();
+        MetricsExporterType metricsExporterType = MetricsExporterType.valueOf(metricsConfig.exporterType());
+        if (metricsExporterType != MetricsExporterType.DISABLE) {
+            initDynamicMetrics();
+        }
         this.started = true;
     }
 


### PR DESCRIPTION
1. Skip initializing StreamMetricsManager when exported disabled