### PR TITLE
chore: opt quick start for docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Compared to Apache RocketMQ, AutoMQ for Apache RocketMQ offers the following adv
 Pre-requirements: docker and docker-compose
 
 1. Clone the project via git: `git clone https://github.com/AutoMQ/automq-for-rocketmq.git && cd automq-for-rocketmq`
-2. Run `./distribution/build.sh` to build the docker image.
-3. Run `./distribution/compose.sh` to start the service, which includes 1 MySQL server and 2 RocketMQ brokers.
+2. Run `./distribution/docker/build.sh` to build the docker image.
+3. Run `./distribution/docker/compose.sh` to start the service, which includes 1 MySQL server and 2 RocketMQ brokers.
 4. Start the producer and consumer to produce and consume messages,
    See [rocketmq-clients](https://github.com/apache/rocketmq-clients) for more details.
 

--- a/distribution/docker/compose.sh
+++ b/distribution/docker/compose.sh
@@ -27,5 +27,6 @@ then
 elif [ "$OS_NAME" == "Darwin" ]; then
   IP=$(ipconfig getifaddr en0)
 fi
-sed -i "s/192.168.123.147/$IP/g" "$SCRIPT_DIR/docker-compose.yaml"
+export EXTERNAL_IP="$IP"
+
 docker compose up

--- a/distribution/docker/docker-compose.yaml
+++ b/distribution/docker/docker-compose.yaml
@@ -1,36 +1,97 @@
-version: "3"
+version: "3.8"
 services:
+  minio:
+    image: minio/minio
+    container_name: minio.local
+    hostname: minio.local
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - s3_data:/data
+    environment:
+      MINIO_ROOT_USER: access-key
+      MINIO_ROOT_PASSWORD: secret-key
+    command: server --console-address ":9001" /data
+    # use a static ip
+    networks:
+      kos_net:
+        ipv4_address: 11.6.0.2
+
+  # create needed buckets
+  aws-cli:
+    container_name: "${AWS_CLI_DOCKER_NAME-aws-cli}"
+    hostname: "${AWS_CLI_DOCKER_NAME-aws-cli}"
+    image: amazon/aws-cli:2.13.29
+    environment:
+      - AWS_ACCESS_KEY_ID=access-key
+      - AWS_SECRET_ACCESS_KEY=secret-key
+      - AWS_DEFAULT_REGION=us-east-1
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        BUCKET_EXISTS=$(aws s3api create-bucket --bucket bucket-name --endpoint=http://11.6.0.2:9000 2>&1 || true);
+        if [ ! -z "$BUCKET_EXISTS"]; then 
+          aws s3api create-bucket --bucket bucket-name --endpoint=http://11.6.0.2:9000
+        fi
+    depends_on:
+      minio:
+        condition: service_started
+    networks:
+      - kos_net
+
   broker-1:
     image: "automq-for-rocketmq:0.0.1"
     # https://docs.docker.com/compose/compose-file/05-services/#entrypoint
     environment:
       - ROCKETMQ_NODE_NAME=broker-1
       - ROCKETMQ_NODE_BIND_ADDRESS=0.0.0.0:8081
-      - ROCKETMQ_NODE_ADVERTISE_ADDRESS=192.168.123.147:8081
+      - ROCKETMQ_NODE_ADVERTISE_ADDRESS=${EXTERNAL_IP}:8081
     ports:
       - "8081:8081"
       - "8082:8082"
+      - "9555:9555"
     # https://docs.docker.com/compose/compose-file/05-services/#depends_on
     depends_on:
       mysql-server:
         condition: service_healthy
+      minio:
+        condition: service_started
+      aws-cli:
+        condition: service_completed_successfully
+    # use a static ip
+    networks:
+      kos_net:
+        ipv4_address: 11.6.0.3
   broker-2:
     image: "automq-for-rocketmq:0.0.1"
     # https://docs.docker.com/compose/compose-file/05-services/#entrypoint
     environment:
       - ROCKETMQ_NODE_NAME=broker-2
       - ROCKETMQ_NODE_BIND_ADDRESS=0.0.0.0:8181
-      - ROCKETMQ_NODE_ADVERTISE_ADDRESS=192.168.123.147:8181
+      - ROCKETMQ_NODE_ADVERTISE_ADDRESS=${EXTERNAL_IP}:8181
     ports:
       - "8181:8181"
       - "8182:8182"
+      - "9556:9555"
     # https://docs.docker.com/compose/compose-file/05-services/#depends_on
     depends_on:
       mysql-server:
         condition: service_healthy
+      minio:
+        condition: service_started
+      aws-cli:
+        condition: service_completed_successfully
+    # use a static ip
+    networks:
+      kos_net:
+        ipv4_address: 11.6.0.4
   mysql-server:
     image: "mysql:8.1"
     command: --default-authentication-plugin=caching_sha2_password
+    container_name: mysql-server
+    hostname: mysql-server
     environment:
       - MYSQL_ROOT_PASSWORD=password
       - MYSQL_DATABASE=metadata
@@ -44,3 +105,20 @@ services:
       test: "mysql --user=root --password=password metadata -e 'select * from metadata.lease'"
       timeout: 20s
       retries: 10
+    # use a static ip
+    networks:
+      kos_net:
+        ipv4_address: 11.6.0.5
+volumes:
+  s3_data:
+    driver: local
+
+networks:
+  kos_net:
+    name: kos_net
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: "11.6.0.0/16"
+          gateway: "11.6.0.1"


### PR DESCRIPTION
change
1. add host ip 
2. add minio and init

Users can directly start copmse without any other dependencies. In previous versions, it was necessary to install miniio, complete configuration, and resolve the issue of secondary IP replacement.