### PR TITLE
perf(wal): speed up recovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <guava.version>32.0.1-jre</guava.version>
         <slf4j.version>2.0.9</slf4j.version>
         <snakeyaml.version>2.2</snakeyaml.version>
-        <s3stream.version>0.4.3-SNAPSHOT</s3stream.version>
+        <s3stream.version>0.5.0-SNAPSHOT</s3stream.version>
 
         <!-- Flat buffers related -->
         <flatbuffers.version>23.5.26</flatbuffers.version>

--- a/s3stream/pom.xml
+++ b/s3stream/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.automq.elasticstream</groupId>
     <artifactId>s3stream</artifactId>
-    <version>0.4.3-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
     <properties>
         <mockito-core.version>5.5.0</mockito-core.version>
         <junit-jupiter.version>5.10.0</junit-jupiter.version>

--- a/s3stream/src/main/java/com/automq/stream/s3/Config.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/Config.java
@@ -31,7 +31,6 @@ public class Config {
     private long walCapacity = 1024L * 1024 * 1024;
     private int walInitBufferSize = 1024 * 1024;
     private int walMaxBufferSize = 16 * 1024 * 1024;
-    private int walHeaderFlushIntervalSeconds = 10;
     private int walThread = 8;
     private long walWindowInitial = 1048576L;
     private long walWindowIncrement = 4194304L;
@@ -103,10 +102,6 @@ public class Config {
 
     public int walMaxBufferSize() {
         return walMaxBufferSize;
-    }
-
-    public int walHeaderFlushIntervalSeconds() {
-        return walHeaderFlushIntervalSeconds;
     }
 
     public int walThread() {
@@ -280,11 +275,6 @@ public class Config {
 
     public Config walMaxBufferSize(int walMaxBufferSize) {
         this.walMaxBufferSize = walMaxBufferSize;
-        return this;
-    }
-
-    public Config walHeaderFlushIntervalSeconds(int s3WALHeaderFlushIntervalSeconds) {
-        this.walHeaderFlushIntervalSeconds = s3WALHeaderFlushIntervalSeconds;
         return this;
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/Config.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/Config.java
@@ -29,6 +29,8 @@ public class Config {
     private String walPath = "/tmp/s3stream_wal";
     private long walCacheSize = 200 * 1024 * 1024;
     private long walCapacity = 1024L * 1024 * 1024;
+    private int walInitBufferSize = 1024 * 1024;
+    private int walMaxBufferSize = 16 * 1024 * 1024;
     private int walHeaderFlushIntervalSeconds = 10;
     private int walThread = 8;
     private long walWindowInitial = 1048576L;
@@ -93,6 +95,14 @@ public class Config {
 
     public long walCapacity() {
         return walCapacity;
+    }
+
+    public int walInitBufferSize() {
+        return walInitBufferSize;
+    }
+
+    public int walMaxBufferSize() {
+        return walMaxBufferSize;
     }
 
     public int walHeaderFlushIntervalSeconds() {
@@ -260,6 +270,16 @@ public class Config {
 
     public Config walCapacity(long s3WALCapacity) {
         this.walCapacity = s3WALCapacity;
+        return this;
+    }
+
+    public Config walInitBufferSize(int walInitBufferSize) {
+        this.walInitBufferSize = walInitBufferSize;
+        return this;
+    }
+
+    public Config walMaxBufferSize(int walMaxBufferSize) {
+        this.walMaxBufferSize = walMaxBufferSize;
         return this;
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/Constants.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/Constants.java
@@ -17,6 +17,7 @@
 package com.automq.stream.s3;
 
 public class Constants {
+    public static final int CAPACITY_NOT_SET = -1;
     public static final int NOOP_NODE_ID = -1;
     public static final long NOOP_EPOCH = -1L;
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/failover/Failover.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/failover/Failover.java
@@ -88,7 +88,7 @@ public class Failover {
             // fence the device to ensure the old node stops writing to the delta WAL
             fence(request);
             // recover WAL data and upload to S3
-            BlockWALService wal = BlockWALService.builder(request.getDevice()).readOnly().build();
+            BlockWALService wal = BlockWALService.builder(request.getDevice()).recoveryMode().build();
             wal.start();
             try {
                 WALMetadata metadata = wal.metadata();

--- a/s3stream/src/main/java/com/automq/stream/s3/failover/Failover.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/failover/Failover.java
@@ -88,7 +88,7 @@ public class Failover {
             // fence the device to ensure the old node stops writing to the delta WAL
             fence(request);
             // recover WAL data and upload to S3
-            BlockWALService wal = BlockWALService.builder(request.getDevice()).recoveryMode().build();
+            BlockWALService wal = BlockWALService.recoveryBuilder(request.getDevice()).build();
             wal.start();
             try {
                 WALMetadata metadata = wal.metadata();

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
@@ -464,8 +464,8 @@ public class BlockWALService implements WriteAheadLog {
 
     private CompletableFuture<Void> trim(long offset, boolean internal) {
         checkReadyToServe();
-        checkWriteMode();
         if (!internal) {
+            checkWriteMode();
             checkResetFinished();
         }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
@@ -759,6 +759,7 @@ public class BlockWALService implements WriteAheadLog {
             if (next != null) {
                 return true;
             }
+            // FIXME: do-while -> while-do
             do {
                 try {
                     boolean skip = nextRecoverOffset == skipRecordAtOffset;
@@ -775,6 +776,8 @@ public class BlockWALService implements WriteAheadLog {
                     if (firstInvalidOffset == -1) {
                         // set to `nextRecoverOffset` is ok too, but it's safer to set to `e.getJumpNextRecoverOffset()`
                         firstInvalidOffset = e.getJumpNextRecoverOffset();
+                        // FIXME: if nextRecoverOffset is not aligned by BLOCK_SIZE, it should not be regarded as invalid offset
+                        firstInvalidOffset = nextRecoverOffset;
                     }
                     nextRecoverOffset = e.getJumpNextRecoverOffset();
                 }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
@@ -773,10 +773,8 @@ public class BlockWALService implements WriteAheadLog {
                     next = recoverResult;
                     return true;
                 } catch (ReadRecordException e) {
-                    if (firstInvalidOffset == -1) {
-                        // set to `nextRecoverOffset` is ok too, but it's safer to set to `e.getJumpNextRecoverOffset()`
-                        firstInvalidOffset = e.getJumpNextRecoverOffset();
-                        // FIXME: if nextRecoverOffset is not aligned by BLOCK_SIZE, it should not be regarded as invalid offset
+                    if (firstInvalidOffset == -1 && WALUtil.isAligned(nextRecoverOffset)) {
+                        // first invalid offset
                         firstInvalidOffset = nextRecoverOffset;
                     }
                     nextRecoverOffset = e.getJumpNextRecoverOffset();

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
@@ -759,8 +759,7 @@ public class BlockWALService implements WriteAheadLog {
             if (next != null) {
                 return true;
             }
-            // FIXME: do-while -> while-do
-            do {
+            while (firstInvalidOffset == -1 || nextRecoverOffset < firstInvalidOffset + windowLength) {
                 try {
                     boolean skip = nextRecoverOffset == skipRecordAtOffset;
                     ByteBuf nextRecordBody = readRecord(walHeader.recordSectionCapacity(), nextRecoverOffset);
@@ -779,7 +778,7 @@ public class BlockWALService implements WriteAheadLog {
                     }
                     nextRecoverOffset = e.getJumpNextRecoverOffset();
                 }
-            } while (firstInvalidOffset == -1 || nextRecoverOffset < firstInvalidOffset + windowLength);
+            }
             return false;
         }
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/WALCapacityMismatchException.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/WALCapacityMismatchException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.wal;
+
+import java.io.IOException;
+
+public class WALCapacityMismatchException extends IOException {
+
+    public WALCapacityMismatchException(String path, long expected, long actual) {
+        super(String.format("WAL capacity mismatch for %s: expected %d, actual %d", path, expected, actual));
+    }
+
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/WALHeader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/WALHeader.java
@@ -38,23 +38,17 @@ import java.util.concurrent.atomic.AtomicLong;
  * 3 - [8B] {@link WALHeader#lastWriteTimestamp3} The timestamp of the last write to the WAL header, used to
  * determine which WAL header is the latest when recovering
  * <p>
- * 4 - [8B] {@link WALHeader#slidingWindowNextWriteOffset4} The offset of the next record to be written
- * in the sliding window
- * <p>
- * 5 - [8B] {@link WALHeader#slidingWindowStartOffset5} The start offset of the sliding window, all records
- * before this offset have been successfully written to the block device
- * <p>
- * 6 - [8B] {@link WALHeader#slidingWindowMaxLength6} The maximum size of the sliding window, which can be
+ * 4 - [8B] {@link WALHeader#slidingWindowMaxLength4} The maximum size of the sliding window, which can be
  * scaled up when needed, and is used to determine when to stop recovering
  * <p>
- * 7 - [4B] {@link WALHeader#shutdownType7} The shutdown type of the service, {@link ShutdownType#GRACEFULLY} or
+ * 5 - [4B] {@link WALHeader#shutdownType5} The shutdown type of the service, {@link ShutdownType#GRACEFULLY} or
  * {@link ShutdownType#UNGRACEFULLY}
  * <p>
- * 8 - [4B] {@link WALHeader#nodeId8} the node id of the WAL
+ * 6 - [4B] {@link WALHeader#nodeId6} the node id of the WAL
  * <p>
- * 9 - [4B] {@link WALHeader#epoch9} the epoch id of the node
+ * 7 - [4B] {@link WALHeader#epoch7} the epoch id of the node
  * <p>
- * 10 - [4B] {@link WALHeader#crc10} CRC of the rest of the WAL header, used to verify the correctness of the
+ * 8 - [4B] {@link WALHeader#crc8} CRC of the rest of the WAL header, used to verify the correctness of the
  * WAL header
  */
 class WALHeader {
@@ -63,8 +57,6 @@ class WALHeader {
             + 8 // capacity
             + 8 // trim offset
             + 8 // last write timestamp
-            + 8 // sliding window next write offset
-            + 8 // sliding window start offset
             + 8 // sliding window max length
             + 4 // shutdown type
             + 4 // node id
@@ -73,31 +65,29 @@ class WALHeader {
     public static final int WAL_HEADER_WITHOUT_CRC_SIZE = WAL_HEADER_SIZE - 4;
     private final AtomicLong trimOffset2 = new AtomicLong(-1);
     private final AtomicLong flushedTrimOffset = new AtomicLong(0);
-    private final AtomicLong slidingWindowNextWriteOffset4 = new AtomicLong(0);
-    private final AtomicLong slidingWindowStartOffset5 = new AtomicLong(0);
-    private final AtomicLong slidingWindowMaxLength6 = new AtomicLong(0);
+    private final AtomicLong slidingWindowMaxLength4 = new AtomicLong(0);
     private int magicCode0 = WAL_HEADER_MAGIC_CODE;
     private long capacity1;
     private long lastWriteTimestamp3 = System.nanoTime();
-    private ShutdownType shutdownType7 = ShutdownType.UNGRACEFULLY;
-    private int nodeId8;
-    private long epoch9;
-    private int crc10;
+    private ShutdownType shutdownType5 = ShutdownType.UNGRACEFULLY;
+    private int nodeId6;
+    private long epoch7;
+    private int crc8;
 
     public static WALHeader unmarshal(ByteBuf buf) throws UnmarshalException {
         WALHeader walHeader = new WALHeader();
         buf.markReaderIndex();
         walHeader.magicCode0 = buf.readInt();
         walHeader.capacity1 = buf.readLong();
-        walHeader.trimOffset2.set(buf.readLong());
+        long trimOffset = buf.readLong();
+        walHeader.trimOffset2.set(trimOffset);
+        walHeader.flushedTrimOffset.set(trimOffset);
         walHeader.lastWriteTimestamp3 = buf.readLong();
-        walHeader.slidingWindowNextWriteOffset4.set(buf.readLong());
-        walHeader.slidingWindowStartOffset5.set(buf.readLong());
-        walHeader.slidingWindowMaxLength6.set(buf.readLong());
-        walHeader.shutdownType7 = ShutdownType.fromCode(buf.readInt());
-        walHeader.nodeId8 = buf.readInt();
-        walHeader.epoch9 = buf.readLong();
-        walHeader.crc10 = buf.readInt();
+        walHeader.slidingWindowMaxLength4.set(buf.readLong());
+        walHeader.shutdownType5 = ShutdownType.fromCode(buf.readInt());
+        walHeader.nodeId6 = buf.readInt();
+        walHeader.epoch7 = buf.readLong();
+        walHeader.crc8 = buf.readInt();
         buf.resetReaderIndex();
 
         if (walHeader.magicCode0 != WAL_HEADER_MAGIC_CODE) {
@@ -105,8 +95,8 @@ class WALHeader {
         }
 
         int crc = WALUtil.crc32(buf, WAL_HEADER_WITHOUT_CRC_SIZE);
-        if (crc != walHeader.crc10) {
-            throw new UnmarshalException(String.format("WALHeader CRC not match, Recovered: [%d] expect: [%d]", walHeader.crc10, crc));
+        if (crc != walHeader.crc8) {
+            throw new UnmarshalException(String.format("WALHeader CRC not match, Recovered: [%d] expect: [%d]", walHeader.crc8, crc));
         }
 
         return walHeader;
@@ -125,15 +115,6 @@ class WALHeader {
         return this;
     }
 
-    public long getSlidingWindowStartOffset() {
-        return slidingWindowStartOffset5.get();
-    }
-
-    public WALHeader setSlidingWindowStartOffset(long slidingWindowStartOffset) {
-        this.slidingWindowStartOffset5.set(slidingWindowStartOffset);
-        return this;
-    }
-
     public long getTrimOffset() {
         return trimOffset2.get();
     }
@@ -148,8 +129,8 @@ class WALHeader {
         return flushedTrimOffset.get();
     }
 
-    public void setFlushedTrimOffset(long flushedTrimOffset) {
-        this.flushedTrimOffset.set(flushedTrimOffset);
+    public void updateFlushedTrimOffset(long flushedTrimOffset) {
+        this.flushedTrimOffset.accumulateAndGet(flushedTrimOffset, Math::max);
     }
 
     public long getLastWriteTimestamp() {
@@ -161,48 +142,39 @@ class WALHeader {
         return this;
     }
 
-    public long getSlidingWindowNextWriteOffset() {
-        return slidingWindowNextWriteOffset4.get();
-    }
-
-    public WALHeader setSlidingWindowNextWriteOffset(long slidingWindowNextWriteOffset) {
-        this.slidingWindowNextWriteOffset4.set(slidingWindowNextWriteOffset);
-        return this;
-    }
-
     public long getSlidingWindowMaxLength() {
-        return slidingWindowMaxLength6.get();
+        return slidingWindowMaxLength4.get();
     }
 
     public WALHeader setSlidingWindowMaxLength(long slidingWindowMaxLength) {
-        this.slidingWindowMaxLength6.set(slidingWindowMaxLength);
+        this.slidingWindowMaxLength4.set(slidingWindowMaxLength);
         return this;
     }
 
     public ShutdownType getShutdownType() {
-        return shutdownType7;
+        return shutdownType5;
     }
 
     public WALHeader setShutdownType(ShutdownType shutdownType) {
-        this.shutdownType7 = shutdownType;
+        this.shutdownType5 = shutdownType;
         return this;
     }
 
     public int getNodeId() {
-        return nodeId8;
+        return nodeId6;
     }
 
     public WALHeader setNodeId(int nodeId) {
-        this.nodeId8 = nodeId;
+        this.nodeId6 = nodeId;
         return this;
     }
 
     public long getEpoch() {
-        return epoch9;
+        return epoch7;
     }
 
     public WALHeader setEpoch(long epoch) {
-        this.epoch9 = epoch;
+        this.epoch7 = epoch;
         return this;
     }
 
@@ -213,13 +185,11 @@ class WALHeader {
                 + ", capacity=" + capacity1
                 + ", trimOffset=" + trimOffset2
                 + ", lastWriteTimestamp=" + lastWriteTimestamp3
-                + ", nextWriteOffset=" + slidingWindowNextWriteOffset4
-                + ", slidingWindowStartOffset=" + slidingWindowStartOffset5
-                + ", slidingWindowMaxLength=" + slidingWindowMaxLength6
-                + ", shutdownType=" + shutdownType7
-                + ", nodeId=" + nodeId8
-                + ", epoch=" + epoch9
-                + ", crc=" + crc10
+                + ", slidingWindowMaxLength=" + slidingWindowMaxLength4
+                + ", shutdownType=" + shutdownType5
+                + ", nodeId=" + nodeId6
+                + ", epoch=" + epoch7
+                + ", crc=" + crc8
                 + '}';
     }
 
@@ -229,19 +199,17 @@ class WALHeader {
         buf.writeLong(capacity1);
         buf.writeLong(trimOffset2.get());
         buf.writeLong(lastWriteTimestamp3);
-        buf.writeLong(slidingWindowNextWriteOffset4.get());
-        buf.writeLong(slidingWindowStartOffset5.get());
-        buf.writeLong(slidingWindowMaxLength6.get());
-        buf.writeInt(shutdownType7.getCode());
-        buf.writeInt(nodeId8);
-        buf.writeLong(epoch9);
+        buf.writeLong(slidingWindowMaxLength4.get());
+        buf.writeInt(shutdownType5.getCode());
+        buf.writeInt(nodeId6);
+        buf.writeLong(epoch7);
         return buf;
     }
 
     ByteBuf marshal() {
         ByteBuf buf = marshalHeaderExceptCRC();
-        this.crc10 = WALUtil.crc32(buf, WAL_HEADER_WITHOUT_CRC_SIZE);
-        buf.writeInt(crc10);
+        this.crc8 = WALUtil.crc32(buf, WAL_HEADER_WITHOUT_CRC_SIZE);
+        buf.writeInt(crc8);
         return buf;
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/WriteBench.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/WriteBench.java
@@ -32,6 +32,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.NavigableSet;
 import java.util.Random;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -60,7 +61,10 @@ public class WriteBench implements AutoCloseable {
         }
         this.log = builder.build();
         this.log.start();
-        this.log.reset();
+        for (Iterator<WriteAheadLog.RecoverResult> it = this.log.recover(); it.hasNext(); ) {
+            it.next().record().release();
+        }
+        this.log.reset().join();
     }
 
     public static void main(String[] args) throws IOException {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
@@ -29,36 +29,57 @@ import java.nio.ByteBuffer;
 
 public class WALBlockDeviceChannel implements WALChannel {
     // TODO: move these to config
+    @Deprecated
     private static final int PRE_ALLOCATED_BYTE_BUFFER_SIZE = Integer.parseInt(System.getProperty(
             "automq.ebswal.preAllocatedByteBufferSize",
             String.valueOf(1024 * 1024 * 2)
     ));
+    @Deprecated
     private static final int PRE_ALLOCATED_BYTE_BUFFER_MAX_SIZE = Integer.parseInt(System.getProperty(
             "automq.ebswal.preAllocatedByteBufferMaxSize",
             String.valueOf(1024 * 1024 * 16)
     ));
 
     final String blockDevicePath;
-    final long capacityWant;
+    final long capacity;
     final DirectIOLib directIOLib;
-
-    long capacityFact = 0;
+    /**
+     * 0 means allocate on demand
+     */
+    final int initTempBufferSize;
+    /**
+     * 0 means no limit
+     */
+    final int maxTempBufferSize;
 
     DirectRandomAccessFile randomAccessFile;
 
     ThreadLocal<ByteBuffer> threadLocalByteBuffer = new ThreadLocal<>() {
         @Override
         protected ByteBuffer initialValue() {
-            return DirectIOUtils.allocateForDirectIO(directIOLib, PRE_ALLOCATED_BYTE_BUFFER_SIZE);
+            if (initTempBufferSize == 0) {
+                // An empty buffer just to avoid NPE
+                return ByteBuffer.allocate(0);
+            }
+            return DirectIOUtils.allocateForDirectIO(directIOLib, initTempBufferSize);
         }
     };
 
     public WALBlockDeviceChannel(String blockDevicePath, long blockDeviceCapacityWant) {
+        this(blockDevicePath, blockDeviceCapacityWant, 0, 0);
+    }
+
+    public WALBlockDeviceChannel(String blockDevicePath, long blockDeviceCapacityWant, int initTempBufferSize, int maxTempBufferSize) {
         this.blockDevicePath = blockDevicePath;
-        this.capacityWant = blockDeviceCapacityWant;
+        // We cannot get the actual capacity of the block device here, so we just use the capacity we want
+        // And it's the caller's responsibility to make sure the capacity is right
+        this.capacity = blockDeviceCapacityWant;
         if (blockDeviceCapacityWant != WALUtil.alignSmallByBlockSize(blockDeviceCapacityWant)) {
             throw new RuntimeException("wal capacity must be aligned by block size when using block device");
         }
+        this.initTempBufferSize = initTempBufferSize;
+        this.maxTempBufferSize = maxTempBufferSize;
+
         DirectIOLib lib = DirectIOLib.getLibForPath(blockDevicePath);
         if (null == lib || !DirectIOLib.binit) {
             throw new RuntimeException("O_DIRECT not supported");
@@ -73,14 +94,11 @@ public class WALBlockDeviceChannel implements WALChannel {
             // If the block device path is not a device, we create a file with the capacity we want
             // This is ONLY for test purpose, so we don't check the capacity of the file
             try (RandomAccessFile raf = new RandomAccessFile(blockDevicePath, "rw")) {
-                raf.setLength(capacityWant);
+                raf.setLength(capacity);
             }
         }
 
         randomAccessFile = new DirectRandomAccessFile(new File(blockDevicePath), "rw");
-        // We cannot get the actual capacity of the block device here, so we just use the capacity we want
-        // And it's the caller's responsibility to make sure the capacity is right
-        capacityFact = capacityWant;
     }
 
     @Override
@@ -96,24 +114,24 @@ public class WALBlockDeviceChannel implements WALChannel {
     @Override
     public long capacity() {
         // FIXME: check the capacity outside
-        return capacityFact;
+        return capacity;
     }
 
     private ByteBuffer getBuffer(int alignedSize) {
         assert alignedSize % WALUtil.BLOCK_SIZE == 0;
 
         ByteBuffer currentBuf = threadLocalByteBuffer.get();
-        if (alignedSize > currentBuf.capacity()) {
-            if (alignedSize <= PRE_ALLOCATED_BYTE_BUFFER_MAX_SIZE) {
-                ByteBuffer newBuf = DirectIOUtils.allocateForDirectIO(directIOLib, alignedSize);
-                threadLocalByteBuffer.set(newBuf);
-                DirectIOUtils.release(currentBuf);
-                return newBuf;
-            } else {
-                throw new RuntimeException("too large write size");
-            }
+        if (alignedSize <= currentBuf.capacity()) {
+            return currentBuf;
         }
-        return currentBuf;
+        if (maxTempBufferSize > 0 && alignedSize > maxTempBufferSize) {
+            throw new RuntimeException("too large write size");
+        }
+
+        ByteBuffer newBuf = DirectIOUtils.allocateForDirectIO(directIOLib, alignedSize);
+        threadLocalByteBuffer.set(newBuf);
+        DirectIOUtils.release(currentBuf);
+        return newBuf;
     }
 
     @Override

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
@@ -113,8 +113,12 @@ public class WALBlockDeviceChannel implements WALChannel {
 
     @Override
     public long capacity() {
-        // FIXME: check the capacity outside
         return capacity;
+    }
+
+    @Override
+    public String path() {
+        return blockDevicePath;
     }
 
     private ByteBuffer getBuffer(int alignedSize) {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
@@ -73,6 +73,7 @@ public class WALBlockDeviceChannel implements WALChannel {
         this.blockDevicePath = blockDevicePath;
         // We cannot get the actual capacity of the block device here, so we just use the capacity we want
         // And it's the caller's responsibility to make sure the capacity is right
+        // FIXME: in recovery mode, `capacity` will be set to CAPACITY_NOT_SET here. It should be corrected after recovery.
         this.capacity = blockDeviceCapacityWant;
         if (blockDeviceCapacityWant != WALUtil.alignSmallByBlockSize(blockDeviceCapacityWant)) {
             throw new RuntimeException("wal capacity must be aligned by block size when using block device");

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
@@ -57,10 +57,6 @@ public class WALBlockDeviceChannel implements WALChannel {
     ThreadLocal<ByteBuffer> threadLocalByteBuffer = new ThreadLocal<>() {
         @Override
         protected ByteBuffer initialValue() {
-            if (initTempBufferSize == 0) {
-                // An empty buffer just to avoid NPE
-                return ByteBuffer.allocate(0);
-            }
             return DirectIOUtils.allocateForDirectIO(directIOLib, initTempBufferSize);
         }
     };
@@ -135,7 +131,7 @@ public class WALBlockDeviceChannel implements WALChannel {
 
         ByteBuffer newBuf = DirectIOUtils.allocateForDirectIO(directIOLib, alignedSize);
         threadLocalByteBuffer.set(newBuf);
-        DirectIOUtils.release(currentBuf);
+        DirectIOUtils.releaseDirectBuffer(currentBuf);
         return newBuf;
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
@@ -73,6 +73,8 @@ public interface WALChannel {
         private final String path;
         private boolean direct;
         private long capacity;
+        private int initBufferSize;
+        private int maxBufferSize;
         private boolean readOnly;
 
         private WALChannelBuilder(String path) {
@@ -89,6 +91,16 @@ public interface WALChannel {
             return this;
         }
 
+        public WALChannelBuilder initBufferSize(int initBufferSize) {
+            this.initBufferSize = initBufferSize;
+            return this;
+        }
+
+        public WALChannelBuilder maxBufferSize(int maxBufferSize) {
+            this.maxBufferSize = maxBufferSize;
+            return this;
+        }
+
         public WALChannelBuilder readOnly(boolean readOnly) {
             this.readOnly = readOnly;
             return this;
@@ -96,7 +108,7 @@ public interface WALChannel {
 
         public WALChannel build() {
             if (direct || path.startsWith(DEVICE_PREFIX)) {
-                return new WALBlockDeviceChannel(path, capacity);
+                return new WALBlockDeviceChannel(path, capacity, initBufferSize, maxBufferSize);
             } else {
                 return new WALFileChannel(path, capacity, readOnly);
             }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
@@ -75,7 +75,7 @@ public interface WALChannel {
         private long capacity;
         private int initBufferSize;
         private int maxBufferSize;
-        private boolean readOnly;
+        private boolean recoveryMode;
 
         private WALChannelBuilder(String path) {
             this.path = path;
@@ -101,8 +101,8 @@ public interface WALChannel {
             return this;
         }
 
-        public WALChannelBuilder readOnly(boolean readOnly) {
-            this.readOnly = readOnly;
+        public WALChannelBuilder recoveryMode(boolean recoveryMode) {
+            this.recoveryMode = recoveryMode;
             return this;
         }
 
@@ -110,7 +110,7 @@ public interface WALChannel {
             if (direct || path.startsWith(DEVICE_PREFIX)) {
                 return new WALBlockDeviceChannel(path, capacity, initBufferSize, maxBufferSize);
             } else {
-                return new WALFileChannel(path, capacity, readOnly);
+                return new WALFileChannel(path, capacity, recoveryMode);
             }
         }
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
@@ -38,6 +38,8 @@ public interface WALChannel {
 
     long capacity();
 
+    String path();
+
     /**
      * Write bytes from the given buffer to the given position of the channel from the current reader index
      * to the end of the buffer. It only returns when all bytes are written successfully.
@@ -107,6 +109,7 @@ public interface WALChannel {
         }
 
         public WALChannel build() {
+            // TODO: If the OS supports O_DIRECT, we use it by default. Otherwise, we use file system.
             if (direct || path.startsWith(DEVICE_PREFIX)) {
                 return new WALBlockDeviceChannel(path, capacity, initBufferSize, maxBufferSize);
             } else {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALFileChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALFileChannel.java
@@ -17,6 +17,7 @@
 
 package com.automq.stream.s3.wal.util;
 
+import com.automq.stream.s3.wal.WALCapacityMismatchException;
 import com.automq.stream.s3.wal.WALNotInitializedException;
 import io.netty.buffer.ByteBuf;
 
@@ -55,7 +56,7 @@ public class WALFileChannel implements WALChannel {
             fileCapacityFact = randomAccessFile.length();
             if (!recoveryMode && fileCapacityFact != fileCapacityWant) {
                 // the file exists but not the same size as requested
-                throw new IOException("file " + filePath + " capacity " + fileCapacityFact + " not equal to requested " + fileCapacityWant);
+                throw new WALCapacityMismatchException(filePath, fileCapacityWant, fileCapacityFact);
             }
         } else {
             if (!file.getParentFile().exists() && !file.getParentFile().mkdirs()) {
@@ -87,6 +88,11 @@ public class WALFileChannel implements WALChannel {
     @Override
     public long capacity() {
         return fileCapacityFact;
+    }
+
+    @Override
+    public String path() {
+        return filePath;
     }
 
     @Override

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALUtil.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALUtil.java
@@ -64,4 +64,8 @@ public class WALUtil {
     public static long alignSmallByBlockSize(long offset) {
         return offset % BLOCK_SIZE == 0 ? offset : offset - offset % BLOCK_SIZE;
     }
+
+    public static boolean isAligned(long offset) {
+        return offset % BLOCK_SIZE == 0;
+    }
 }

--- a/s3stream/src/main/java/com/automq/stream/thirdparty/moe/cnkirito/kdio/DirectIOUtils.java
+++ b/s3stream/src/main/java/com/automq/stream/thirdparty/moe/cnkirito/kdio/DirectIOUtils.java
@@ -65,7 +65,8 @@ public class DirectIOUtils {
     /**
      * Release the memory of the buffer.
      */
-    public static void release(ByteBuffer buffer) {
+    public static void releaseDirectBuffer(ByteBuffer buffer) {
+        assert buffer.isDirect();
         PlatformDependent.freeDirectBuffer(buffer);
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/failover/FailoverTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/failover/FailoverTest.java
@@ -58,7 +58,7 @@ public class FailoverTest {
 
     @Test
     public void test() throws IOException, ExecutionException, InterruptedException, TimeoutException {
-        BlockWALService wal = new BlockWALService.BlockWALServiceBuilder(path, 1024 * 1024).nodeId(233).epoch(100).build();
+        BlockWALService wal = BlockWALService.builder(path, 1024 * 1024).nodeId(233).epoch(100).build();
         wal.start();
         wal.shutdownGracefully();
 
@@ -71,7 +71,7 @@ public class FailoverTest {
 
         boolean exceptionThrown = false;
         try {
-            failover.failover(request).get(1, TimeUnit.SECONDS);
+            failover.failover(request).get(100, TimeUnit.SECONDS);
         } catch (ExecutionException e) {
             if (e.getCause() instanceof IllegalArgumentException) {
                 exceptionThrown = true;

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/BlockWALServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/BlockWALServiceTest.java
@@ -711,7 +711,7 @@ class BlockWALServiceTest {
                         100L,
                         20230920L,
                         50L,
-                        Arrays.asList(20230900L, 20230910L, 20230916L, 20230920L, 20230930L, 20230940L, 20230950L, 20230960L, 20230970L),
+                        Arrays.asList(20230900L, 20230910L, 20230916L, 20230920L, 20230930L, 20230940L, 20230950L, 20230960L, 20230970L, 20230980L),
                         Arrays.asList(20230930L, 20230940L, 20230950L, 20230960L, 20230970L),
                         WALUtil.BLOCK_SIZE
                 ).toArguments("big logic offset"),
@@ -721,7 +721,7 @@ class BlockWALServiceTest {
                         180L,
                         50L,
                         Arrays.asList(150L, 160L, 170L, 180L, 190L, 200L, 202L, 210L, 220L, 230L, 240L),
-                        Arrays.asList(190L, 200L, 202L, 210L, 220L, 230L, 240L),
+                        Arrays.asList(190L, 200L, 202L, 210L, 220L, 230L),
                         WALUtil.BLOCK_SIZE
                 ).toArguments("round robin"),
                 new RecoverFromDisasterParam(
@@ -731,10 +731,72 @@ class BlockWALServiceTest {
                         50L,
                         Arrays.asList(111L, 113L, 115L, 117L, 119L, 120L, 130L,
                                 210L, 215L, 220L, 230L, 240L, 250L, 260L, 270L, 280L, 290L),
-                        Arrays.asList(215L, 220L, 230L, 240L, 250L, 260L, 270L, 280L, 290L),
+                        Arrays.asList(215L, 220L, 230L, 240L, 250L, 260L),
                         WALUtil.BLOCK_SIZE
                 ).toArguments("overwrite"),
-                // TODO: test window max length
+                new RecoverFromDisasterParam(
+                        WALUtil.BLOCK_SIZE + 1,
+                        100L,
+                        -1L,
+                        1L,
+                        Arrays.asList(0L, 2L, 5L, 7L),
+                        List.of(0L, 2L),
+                        WALUtil.BLOCK_SIZE
+                ).toArguments("small window - record size not aligned"),
+                new RecoverFromDisasterParam(
+                        WALUtil.BLOCK_SIZE + 1,
+                        100L,
+                        10L,
+                        3L,
+                        Arrays.asList(10L, 12L, 15L, 17L, 19L),
+                        List.of(12L, 15L),
+                        WALUtil.BLOCK_SIZE
+                ).toArguments("invalid record in window - record size not aligned"),
+                new RecoverFromDisasterParam(
+                        WALUtil.BLOCK_SIZE + 1,
+                        100L,
+                        10L,
+                        9L,
+                        Arrays.asList(9L, 13L, 17L, 19L),
+                        List.of(13L, 17L),
+                        WALUtil.BLOCK_SIZE
+                ).toArguments("trim at an invalid record - record size not aligned"),
+                new RecoverFromDisasterParam(
+                        WALUtil.BLOCK_SIZE,
+                        100L,
+                        -1L,
+                        1L,
+                        Arrays.asList(0L, 1L, 3L, 4L, 5L),
+                        List.of(0L, 1L),
+                        WALUtil.BLOCK_SIZE
+                ).toArguments("small window - record size aligned"),
+                new RecoverFromDisasterParam(
+                        WALUtil.BLOCK_SIZE,
+                        100L,
+                        10L,
+                        3L,
+                        Arrays.asList(10L, 11L, 13L, 14L, 15L, 16L),
+                        List.of(11L, 13L, 14L),
+                        WALUtil.BLOCK_SIZE
+                ).toArguments("invalid record in window - record size aligned"),
+                new RecoverFromDisasterParam(
+                        WALUtil.BLOCK_SIZE,
+                        100L,
+                        10L,
+                        5L,
+                        Arrays.asList(9L, 11L, 13L, 14L, 15L, 16L),
+                        List.of(11L, 13L, 14L, 15L),
+                        WALUtil.BLOCK_SIZE
+                ).toArguments("trim at an invalid record - record size aligned"),
+                new RecoverFromDisasterParam(
+                        WALUtil.BLOCK_SIZE,
+                        100L,
+                        10L,
+                        0L,
+                        Arrays.asList(10L, 11L, 12L, 14L),
+                        List.of(11L, 12L),
+                        WALUtil.BLOCK_SIZE
+                ).toArguments("zero window"),
                 new RecoverFromDisasterParam(
                         42,
                         8192L,
@@ -748,7 +810,7 @@ class BlockWALServiceTest {
                         42,
                         8192L,
                         42L,
-                        50L,
+                        8192L,
                         Arrays.asList(0L, 42L, 84L, 126L),
                         Arrays.asList(84L, 126L),
                         1
@@ -757,7 +819,7 @@ class BlockWALServiceTest {
                         42,
                         8192L,
                         42L,
-                        50L,
+                        8192L,
                         Arrays.asList(0L, 42L, 42 * 2L, 42 * 4L, 4096L, 4096L + 42L, 4096L + 42 * 3L),
                         Arrays.asList(42 * 2L, 4096L, 4096L + 42L),
                         1
@@ -766,7 +828,7 @@ class BlockWALServiceTest {
                         42,
                         8192L,
                         42L,
-                        50L,
+                        8192L,
                         Arrays.asList(42L, 42 * 4L, 42 * 2L, 4096L + 42 * 3L, 0L, 4096L, 4096L + 42L),
                         Arrays.asList(42 * 2L, 4096L, 4096L + 42L),
                         1
@@ -775,7 +837,7 @@ class BlockWALServiceTest {
                         1000,
                         8192L,
                         2000L,
-                        50L,
+                        8192L,
                         Arrays.asList(0L, 1000L, 2000L, 3000L, 4000L, 5000L, 7000L),
                         Arrays.asList(3000L, 4000L, 5000L),
                         1
@@ -784,7 +846,7 @@ class BlockWALServiceTest {
                         42,
                         8192L,
                         8192L + 4096L + 42L,
-                        50L,
+                        8192L,
                         Arrays.asList(8192L + 4096L, 8192L + 4096L + 42L, 8192L + 4096L + 42 * 2L, 8192L + 4096L + 42 * 4L, 16384L, 16384L + 42L, 16384L + 42 * 3L),
                         Arrays.asList(8192L + 4096L + 42 * 2L, 16384L, 16384L + 42L),
                         1
@@ -793,12 +855,70 @@ class BlockWALServiceTest {
                         1000,
                         8192L,
                         12000L,
-                        50L,
+                        8192L,
                         Arrays.asList(1000L, 2000L, 3000L, 4000L, 5000L, 6000L, 7000L,
                                 9000L, 10000L, 11000L, 12000L, 13000L, 14000L, 15000L),
                         Arrays.asList(13000L, 14000L, 15000L),
                         1
-                ).toArguments("merge write - overwrite")
+                ).toArguments("merge write - overwrite"),
+                new RecoverFromDisasterParam(
+                        42,
+                        8192L,
+                        -1L,
+                        4096L,
+                        Arrays.asList(0L, 42L, 42 * 3L, 4096L, 4096L + 42L, 4096L + 42 * 3L, 12288L, 12288L + 42L, 12288L + 42 * 3L, 16384L),
+                        Arrays.asList(0L, 42L, 4096L, 4096L + 42L),
+                        1
+                ).toArguments("merge write - small window"),
+                new RecoverFromDisasterParam(
+                        42,
+                        4096L * 20,
+                        4096L * 2,
+                        4096L * 4,
+                        Arrays.asList(4096L * 2, 4096L * 2 + 42L, 4096L * 2 + 42 * 3L,
+                                4096L * 4, 4096L * 4 + 42L, 4096L * 4 + 42 * 3L,
+                                4096L * 5, 4096L * 5 + 42L, 4096L * 5 + 42 * 3L,
+                                4096L * 6, 4096L * 6 + 42L, 4096L * 6 + 42 * 3L,
+                                4096L * 7, 4096L * 7 + 42L, 4096L * 7 + 42 * 3L,
+                                4096L * 8),
+                        Arrays.asList(4096L * 2 + 42L, 4096L * 4, 4096L * 4 + 42L,
+                                4096L * 5, 4096L * 5 + 42L, 4096L * 6, 4096L * 6 + 42L),
+                        1
+                ).toArguments("merge write - invalid record in window"),
+                new RecoverFromDisasterParam(
+                        42,
+                        4096L * 20,
+                        4096L * 2 + 42 * 2L,
+                        4096L * 2,
+                        Arrays.asList(4096L * 2, 4096L * 2 + 42L, 4096L * 2 + 42 * 3L,
+                                4096L * 3, 4096L * 3 + 42L, 4096L * 3 + 42 * 3L,
+                                4096L * 5, 4096L * 5 + 42L, 4096L * 5 + 42 * 3L,
+                                4096L * 6, 4096L * 6 + 42L, 4096L * 6 + 42 * 3L,
+                                4096L * 7),
+                        Arrays.asList(4096L * 4, 4096L * 4 + 42L, 4096L * 5, 4096L * 5 + 42L),
+                        1
+                ).toArguments("merge write - trim at an invalid record"),
+                new RecoverFromDisasterParam(
+                        42,
+                        4096L * 20,
+                        4096L * 2,
+                        0L,
+                        Arrays.asList(4096L * 2, 4096L * 2 + 42L, 4096L * 2 + 42 * 3L,
+                                4096L * 3, 4096L * 3 + 42L, 4096L * 3 + 42 * 3L,
+                                4096L * 5, 4096L * 5 + 42L, 4096L * 5 + 42 * 3L,
+                                4096L * 6),
+                        Arrays.asList(4096L * 2 + 42L, 4096L * 3, 4096L * 3 + 42L),
+                        1
+                ).toArguments("merge write - zero window"),
+                new RecoverFromDisasterParam(
+                        42,
+                        8192L,
+                        42L,
+                        8192L,
+                        Arrays.asList(0L, 42L, 42 * 2L, 42 * 4L, 4096L, 4096L + 42L, 4096L + 42 * 3L),
+                        Arrays.asList(42 * 2L, 4096L, 4096L + 42L),
+                        1
+                ).toArguments("todo: delete me")
         );
     }
 

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/BlockWALServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/BlockWALServiceTest.java
@@ -757,8 +757,8 @@ class BlockWALServiceTest {
                         100L,
                         10L,
                         9L,
-                        Arrays.asList(9L, 13L, 17L, 19L),
-                        List.of(13L, 17L),
+                        Arrays.asList(9L, 14L, 18L, 20L),
+                        List.of(14L, 18L),
                         WALUtil.BLOCK_SIZE
                 ).toArguments("trim at an invalid record - record size not aligned"),
                 new RecoverFromDisasterParam(
@@ -784,8 +784,8 @@ class BlockWALServiceTest {
                         100L,
                         10L,
                         5L,
-                        Arrays.asList(9L, 11L, 13L, 14L, 15L, 16L),
-                        List.of(11L, 13L, 14L, 15L),
+                        Arrays.asList(9L, 11L, 13L, 15L, 16L, 17L),
+                        List.of(11L, 13L, 15L, 16L),
                         WALUtil.BLOCK_SIZE
                 ).toArguments("trim at an invalid record - record size aligned"),
                 new RecoverFromDisasterParam(
@@ -863,7 +863,7 @@ class BlockWALServiceTest {
                 ).toArguments("merge write - overwrite"),
                 new RecoverFromDisasterParam(
                         42,
-                        8192L,
+                        4096L * 20,
                         -1L,
                         4096L,
                         Arrays.asList(0L, 42L, 42 * 3L, 4096L, 4096L + 42L, 4096L + 42 * 3L, 12288L, 12288L + 42L, 12288L + 42 * 3L, 16384L),
@@ -895,7 +895,7 @@ class BlockWALServiceTest {
                                 4096L * 5, 4096L * 5 + 42L, 4096L * 5 + 42 * 3L,
                                 4096L * 6, 4096L * 6 + 42L, 4096L * 6 + 42 * 3L,
                                 4096L * 7),
-                        Arrays.asList(4096L * 4, 4096L * 4 + 42L, 4096L * 5, 4096L * 5 + 42L),
+                        Arrays.asList(4096L * 3, 4096L * 3 + 42L, 4096L * 5, 4096L * 5 + 42L),
                         1
                 ).toArguments("merge write - trim at an invalid record"),
                 new RecoverFromDisasterParam(
@@ -909,16 +909,7 @@ class BlockWALServiceTest {
                                 4096L * 6),
                         Arrays.asList(4096L * 2 + 42L, 4096L * 3, 4096L * 3 + 42L),
                         1
-                ).toArguments("merge write - zero window"),
-                new RecoverFromDisasterParam(
-                        42,
-                        8192L,
-                        42L,
-                        8192L,
-                        Arrays.asList(0L, 42L, 42 * 2L, 42 * 4L, 4096L, 4096L + 42L, 4096L + 42 * 3L),
-                        Arrays.asList(42 * 2L, 4096L, 4096L + 42L),
-                        1
-                ).toArguments("todo: delete me")
+                ).toArguments("merge write - zero window")
         );
     }
 

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/WALHeaderTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/WALHeaderTest.java
@@ -29,8 +29,6 @@ public class WALHeaderTest {
         header.setCapacity(128 * 1024);
         header.updateTrimOffset(10);
         header.setLastWriteTimestamp(11);
-        header.setSlidingWindowNextWriteOffset(20);
-        header.setSlidingWindowStartOffset(15);
         header.setSlidingWindowMaxLength(100);
         header.setShutdownType(ShutdownType.GRACEFULLY);
         header.setNodeId(233);
@@ -40,8 +38,6 @@ public class WALHeaderTest {
         assertEquals(header.getCapacity(), unmarshal.getCapacity());
         assertEquals(header.getTrimOffset(), unmarshal.getTrimOffset());
         assertEquals(header.getLastWriteTimestamp(), unmarshal.getLastWriteTimestamp());
-        assertEquals(header.getSlidingWindowNextWriteOffset(), unmarshal.getSlidingWindowNextWriteOffset());
-        assertEquals(header.getSlidingWindowStartOffset(), unmarshal.getSlidingWindowStartOffset());
         assertEquals(header.getSlidingWindowMaxLength(), unmarshal.getSlidingWindowMaxLength());
         assertEquals(header.getShutdownType(), unmarshal.getShutdownType());
         assertEquals(header.getNodeId(), unmarshal.getNodeId());


### PR DESCRIPTION
- feat
  - "recovery mode" (previously called "read-only") support
- refactor
  - remove `windowStartOffset` and `windowNextOffset` in `WALHeader`
  - remove `flushWALHeaderScheduler`
- perf
  - recover only once, which means there's no recovery on startup
  - read `windowMaxLength` rather than the whole WAL during recovery