### PR TITLE
fix: include node-id in close-stream-request during forwarding requests

### DIFF
--- a/controller/src/main/java/com/automq/rocketmq/controller/server/store/impl/StreamManager.java
+++ b/controller/src/main/java/com/automq/rocketmq/controller/server/store/impl/StreamManager.java
@@ -417,6 +417,7 @@ public class StreamManager {
                 CloseStreamRequest request = CloseStreamRequest.newBuilder()
                     .setStreamId(streamId)
                     .setStreamEpoch(streamEpoch)
+                    .setBrokerId(nodeId)
                     .build();
                 return metadataStore.controllerClient()
                     .closeStream(leaderAddress.get(), request)


### PR DESCRIPTION
fix #737 