### PR TITLE
chore: support helm chart defaults to deploy full clusters

### DIFF
--- a/distribution/helm/charts/automq-for-rocketmq/Chart.yaml
+++ b/distribution/helm/charts/automq-for-rocketmq/Chart.yaml
@@ -38,3 +38,15 @@ version: 0.0.3
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.0.3"
+
+
+dependencies:
+  - name: mysql
+    version: "9.14.1"
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: mysql.enabled
+
+  - name: localstack
+    version: "0.6.5"
+    repository: "https://localstack.github.io/helm-charts"
+    condition: localstack.enabled

--- a/distribution/helm/charts/automq-for-rocketmq/templates/broker/configmap.yaml
+++ b/distribution/helm/charts/automq-for-rocketmq/templates/broker/configmap.yaml
@@ -21,3 +21,180 @@ metadata:
     {{- include "rocketmq-broker.labels" . | nindent 4 }}
 data:
 {{- include "rocketmq-broker.config" . }}
+
+---
+{{- if .Values.mysql.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-initdb-config
+data:
+  initdb.sql: |
+    use metadata;
+    CREATE TABLE IF NOT EXISTS lease
+    (
+        node_id         INT      NOT NULL,
+        epoch           INT      NOT NULL DEFAULT 0,
+        expiration_time DATETIME NOT NULL
+    );
+
+    INSERT INTO lease(node_id, epoch, expiration_time)
+    VALUES (0, 0, TIMESTAMP('2023-01-01'));
+
+    CREATE TABLE IF NOT EXISTS node
+    (
+        id          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+        name        VARCHAR(255) NOT NULL,
+        instance_id VARCHAR(255),
+        volume_id   VARCHAR(255),
+        hostname    VARCHAR(255),
+        vpc_id      VARCHAR(255),
+        address     VARCHAR(255) NOT NULL,
+        epoch       INT          NOT NULL DEFAULT 0,
+        create_time DATETIME              DEFAULT CURRENT_TIMESTAMP,
+        update_time DATETIME              DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE INDEX idx_name (name),
+        UNIQUE INDEX idx_host_name (hostname),
+        UNIQUE INDEX idx_address (address)
+    );
+
+    CREATE TABLE IF NOT EXISTS topic
+    (
+        id                   BIGINT       NOT NULL PRIMARY KEY AUTO_INCREMENT,
+        name                 VARCHAR(255) NOT NULL,
+        queue_num            INT          NOT NULL DEFAULT 0,
+        retention_hours      INT          NOT NULL DEFAULT 72,
+        status               TINYINT               DEFAULT 0,
+        create_time          DATETIME              DEFAULT current_timestamp,
+        update_time          DATETIME              DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        accept_message_types JSON         NOT NULL,
+        UNIQUE INDEX idx_topic_name (name)
+    );
+
+    CREATE TABLE IF NOT EXISTS queue_assignment
+    (
+        topic_id    BIGINT  NOT NULL,
+        queue_id    INT     NOT NULL,
+        src_node_id INT     NOT NULL,
+        dst_node_id INT     NOT NULL,
+        status      TINYINT NOT NULL,
+        create_time DATETIME DEFAULT CURRENT_TIMESTAMP,
+        update_time DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE IF NOT EXISTS stream
+    (
+        id           BIGINT    NOT NULL PRIMARY KEY AUTO_INCREMENT,
+        topic_id     BIGINT    NOT NULL,
+        queue_id     INT       NOT NULL,
+        stream_role  TINYINT   NOT NULL DEFAULT 0,
+        group_id     BIGINT    NULL,
+        src_node_id  INT,
+        dst_node_id  INT,
+        epoch        BIGINT    NOT NULL DEFAULT -1,
+        range_id     INT       NOT NULL DEFAULT -1,
+        start_offset BIGINT    NOT NULL DEFAULT 0,
+        state        INT       NOT NULL DEFAULT 1,
+        create_time  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        update_time  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE INDEX idx_queue (topic_id, queue_id, group_id, stream_role)
+    );
+
+    CREATE TABLE IF NOT EXISTS consumer_group
+    (
+        id                   BIGINT       NOT NULL PRIMARY KEY AUTO_INCREMENT,
+        name                 VARCHAR(255) NOT NULL,
+        status               TINYINT      NOT NULL DEFAULT 0,
+        dead_letter_topic_id BIGINT       NOT NULL DEFAULT 0,
+        max_delivery_attempt INT          NOT NULL DEFAULT 16,
+        group_type           TINYINT      NOT NULL DEFAULT 0,
+        sub_mode             TINYINT      NOT NULL DEFAULT 0,
+        create_time          DATETIME              DEFAULT CURRENT_TIMESTAMP,
+        update_time          DATETIME              DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE INDEX idx_name (name)
+    );
+
+    CREATE TABLE IF NOT EXISTS subscription
+    (
+        id          BIGINT       NOT NULL PRIMARY KEY AUTO_INCREMENT,
+        group_id    BIGINT       NOT NULL,
+        topic_id    BIGINT       NOT NULL,
+        expression  VARCHAR(255) NOT NULL,
+        create_time DATETIME DEFAULT CURRENT_TIMESTAMP,
+        update_time DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE INDEX idx_subscription_group_topic (group_id, topic_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS group_progress
+    (
+        group_id     BIGINT NOT NULL,
+        topic_id     BIGINT NOT NULL,
+        queue_id     INT    NOT NULL,
+        queue_offset BIGINT NOT NULL,
+        UNIQUE INDEX idx_group_progress (group_id, topic_id, queue_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS `range`
+    (
+        id           BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+        range_id     INT    NOT NULL,
+        stream_id    BIGINT NOT NULL,
+        epoch        BIGINT NOT NULL,
+        start_offset BIGINT NOT NULL,
+        end_offset   BIGINT NOT NULL,
+        node_id      INT    NOT NULL,
+        UNIQUE INDEX idx_stream_range (stream_id, range_id),
+        INDEX idx_stream_start_offset (stream_id, start_offset)
+    );
+
+    CREATE TABLE IF NOT EXISTS s3object
+    (
+        id                            BIGINT       NOT NULL PRIMARY KEY,
+        object_size                   BIGINT,
+        stream_id                     BIGINT,
+        prepared_timestamp            TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+        committed_timestamp           TIMESTAMP(3),
+        expired_timestamp             TIMESTAMP(3) NOT NULL,
+        marked_for_deletion_timestamp TIMESTAMP(3),
+        state                         TINYINT      NOT NULL DEFAULT 1
+    );
+
+    CREATE TABLE IF NOT EXISTS s3streamobject
+    (
+        id                  BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+        stream_id           BIGINT NOT NULL,
+        start_offset        BIGINT NOT NULL,
+        end_offset          BIGINT NOT NULL,
+        object_id           BIGINT NOT NULL,
+        object_size         BIGINT NOT NULL,
+        base_data_timestamp TIMESTAMP(3),
+        committed_timestamp TIMESTAMP(3),
+        created_timestamp   TIMESTAMP(3),
+        UNIQUE INDEX uk_s3_stream_object_object_id (object_id),
+        INDEX idx_s3_stream_object_stream_id (stream_id, start_offset)
+    );
+
+    CREATE TABLE IF NOT EXISTS s3streamsetobject
+    (
+        object_id           BIGINT NOT NULL,
+        object_size         BIGINT NOT NULL,
+        node_id             INT    NOT NULL,
+        sequence_id         BIGINT NOT NULL,
+        sub_streams         JSON   NOT NULL, -- immutable
+        base_data_timestamp TIMESTAMP(3),
+        committed_timestamp TIMESTAMP(3),
+        created_timestamp   TIMESTAMP(3),
+        UNIQUE INDEX uk_s3_stream_set_object_node_sequence_id (node_id, sequence_id),
+        INDEX idx_s3_stream_set_object_object_id (object_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS sequence
+    (
+        name VARCHAR(255) NOT NULL,
+        next BIGINT       NOT NULL DEFAULT 1,
+        UNIQUE INDEX idx_name (name)
+    );
+    INSERT INTO sequence(name)
+    VALUES ('S3_OBJECT_ID_SEQ');
+
+{{- end }}

--- a/distribution/helm/charts/automq-for-rocketmq/values.yaml
+++ b/distribution/helm/charts/automq-for-rocketmq/values.yaml
@@ -40,21 +40,21 @@ broker:
       secretKey: "rocketmq"
 
     s3Stream:
-      s3WALPath: "/root/logs/rocketmqlogs"
-      s3Endpoint: "http://minio.local:9000"
-      s3Bucket: "bucket-name"
-      s3Region: "us-east-1"
+      s3WALPath: "/root/logs/rocketmqlogs/s3rocketmq/wal"
+      s3Endpoint: "http://automq-for-rocketmq-localstack:4566"
+      s3Bucket: "automq-for-rocketmq"
+      s3Region: "eu-west-2"
       s3ForcePathStyle: true
       s3AccessKey: "access-key"
       s3SecretKey: "secret-key"
       networkBaselineBandwidth: 5242880
       refillPeriodMs: 100
     db:
-      url: "jdbc:mysql://mysql-server:3306/metadata"
+      url: "jdbc:mysql://automq-for-rocketmq-mysql:3306/metadata"
       userName: "root"
-      password: "password"
+      password: "automq"
     store:
-      kvPath: "/tmp/s3rocketmq/kvstore"
+      kvPath: "/root/logs/rocketmqlogs/s3rocketmq/kvstore"
     controller:
       recycleS3IntervalInSecs: 360
       dumpHeapOnError: true
@@ -84,4 +84,51 @@ broker:
   nodeSelector: { }
 
   tolerations: [ ]
+
+mysql:
+  enabled: true
+  image:
+    tag: 8.0.35
+
+  auth:
+    rootPassword: "automq"
+    createDatabase: true
+    database: metadata
+
+  service:
+    type: LoadBalancer
+
+  primary:
+    extraVolumeMounts: |
+      - name: init
+        mountPath: /docker-entrypoint-initdb.d/
+    extraVolumes: |
+      - name: init
+        configMap:
+          name: mysql-initdb-config
+
+localstack:
+  enabled: true
+  enableStartupScripts: true
+
+  service:
+    type: ClusterIP
+
+  startupScriptContent: |
+    #!/bin/bash
+    set -e
+    export TERM=ansi
+    export AWS_ACCESS_KEY_ID=access-key
+    export AWS_SECRET_ACCESS_KEY=secret-keys
+    export AWS_DEFAULT_REGION=eu-west-2
+    export AWS_DEFAULT_BUCKETS=automq-for-rocketmq
+    export AWS_S3_ENDPOINT=http://localhost:4566
+    export PAGER=
+    
+    echo "S3 Configuration started"
+    
+    aws --endpoint-url=$AWS_S3_ENDPOINT s3 mb s3://$AWS_DEFAULT_BUCKETS
+    aws --endpoint-url=$AWS_S3_ENDPOINT s3 cp /tmp/localstack/test-data/ s3://$AWS_DEFAULT_BUCKETS/chart --recursive
+    
+    echo "S3 Configured"
 

--- a/distribution/helm/deploy-ci.sh
+++ b/distribution/helm/deploy-ci.sh
@@ -67,6 +67,8 @@ helm install mysql bitnami/mysql -f deploy/mysql.yaml --namespace $NAMESPACE
 # Wait for mysql to be ready
 kubectl rollout status --watch --timeout=120s statefulset/mysql --namespace $NAMESPACE
 
+helm dependency build ./charts/automq-for-rocketmq
+
 # deploy automq-for-rocketmq
 helm install automq-for-rocketmq ./charts/automq-for-rocketmq  -f deploy/helm_sample_values.yaml --set broker.image.repository=$ROCKETMQ_REPO --set broker.image.tag=$ROCKETMQ_VERSION --namespace $NAMESPACE
 

--- a/distribution/helm/deploy/helm_sample_values.yaml
+++ b/distribution/helm/deploy/helm_sample_values.yaml
@@ -36,3 +36,9 @@ broker:
     controller:
       recycleS3IntervalInSecs: 360
       dumpHeapOnError: true
+
+mysql:
+  enabled: false
+
+localstack:
+  enabled: false


### PR DESCRIPTION
fixes: https://github.com/AutoMQ/automq-for-rocketmq/issues/768
change:
1. add dependencies for MySQL and Localstack in the helm chart;
2. add a condition for deploying Mysql and Localstack on required；
3. update deploy-ci for new charts;

user stories:
```
helm dependency build ./distribution/charts/automq-for-rocketmq
helm install automq-for-rocketmq  ./distribution/charts/automq-for-rocketmq
```