### PR TITLE
feat(s3stream): block cache memory optimization

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/api/Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/api/Stream.java
@@ -58,6 +58,7 @@ public interface Stream {
 
     /**
      * Fetch recordBatch list from stream. Note the startOffset may be in the middle in the first recordBatch.
+     * It is strongly recommended to handle the completion of the returned CompletableFuture in a separate thread.
      *
      * @param startOffset  start offset, if the startOffset in middle of a recordBatch, the recordBatch will be returned.
      * @param endOffset    exclusive end offset, if the endOffset in middle of a recordBatch, the recordBatch will be returned.

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -342,7 +342,6 @@ public class S3Storage implements Storage {
         return cf;
     }
 
-
     private CompletableFuture<ReadDataBlock> read0(long streamId, long startOffset, long endOffset, int maxBytes, ReadOptions readOptions) {
         List<StreamRecordBatch> logCacheRecords = deltaWALCache.get(streamId, startOffset, endOffset, maxBytes);
         if (!logCacheRecords.isEmpty() && logCacheRecords.get(0).getBaseOffset() <= startOffset) {
@@ -357,7 +356,7 @@ public class S3Storage implements Storage {
         if (!logCacheRecords.isEmpty()) {
             endOffset = logCacheRecords.get(0).getBaseOffset();
         }
-        return blockCache.read(streamId, startOffset, endOffset, maxBytes).thenApplyAsync(readDataBlock -> {
+        return blockCache.read(streamId, startOffset, endOffset, maxBytes).thenApply(readDataBlock -> {
             List<StreamRecordBatch> rst = new ArrayList<>(readDataBlock.getRecords());
             int remainingBytesSize = maxBytes - rst.stream().mapToInt(StreamRecordBatch::size).sum();
             int readIndex = -1;

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/DataBlockReadAccumulator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/DataBlockReadAccumulator.java
@@ -18,10 +18,13 @@
 package com.automq.stream.s3.cache;
 
 import com.automq.stream.s3.ObjectReader;
+import com.automq.stream.s3.StreamDataBlock;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,42 +37,58 @@ public class DataBlockReadAccumulator {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataBlockReadAccumulator.class);
     private final Map<Pair<String, Integer>, DataBlockRecords> inflightDataBlockReads = new ConcurrentHashMap<>();
 
-    public CompletableFuture<DataBlockRecords> readDataBlock(ObjectReader reader, ObjectReader.DataBlockIndex blockIndex) {
-        CompletableFuture<DataBlockRecords> cf = new CompletableFuture<>();
-        BiConsumer<DataBlockRecords, Throwable> listener = (rst, ex) -> {
-            if (ex != null) {
-                cf.completeExceptionally(ex);
-                rst.release();
-            } else {
-                // consumer of DataBlockRecords should release it on completion
-                cf.complete(rst);
+    public List<ReserveResult> reserveDataBlock(List<Pair<ObjectReader, StreamDataBlock>> dataBlockPairList) {
+        List<ReserveResult> reserveResults = new ArrayList<>();
+        synchronized (inflightDataBlockReads) {
+            for (Pair<ObjectReader, StreamDataBlock> pair : dataBlockPairList) {
+                ObjectReader reader = pair.getLeft();
+                ObjectReader.DataBlockIndex blockIndex = pair.getRight().dataBlockIndex();
+                Pair<String, Integer> key = Pair.of(reader.objectKey(), blockIndex.blockId());
+                DataBlockRecords records = inflightDataBlockReads.get(key);
+                CompletableFuture<DataBlockRecords> cf = new CompletableFuture<>();
+                BiConsumer<DataBlockRecords, Throwable> listener = (rst, ex) -> {
+                    if (ex != null) {
+                        cf.completeExceptionally(ex);
+                        rst.release();
+                    } else {
+                        // consumer of DataBlockRecords should release it on completion
+                        cf.complete(rst);
+                    }
+                };
+                int reservedSize = 0;
+                if (records == null) {
+                    records = new DataBlockRecords();
+                    records.registerListener(listener);
+                    inflightDataBlockReads.put(key, records);
+                    reservedSize = blockIndex.size();
+                } else {
+                    records.registerListener(listener);
+                }
+                reserveResults.add(new ReserveResult(reservedSize, cf));
             }
-        };
+        }
+        return reserveResults;
+    }
+
+    public void readDataBlock(ObjectReader reader, ObjectReader.DataBlockIndex blockIndex) {
         Pair<String, Integer> key = Pair.of(reader.objectKey(), blockIndex.blockId());
-        // TODO: limit inflight memory usage
         synchronized (inflightDataBlockReads) {
             DataBlockRecords records = inflightDataBlockReads.get(key);
-            if (records == null) {
-                records = new DataBlockRecords();
-                records.registerListener(listener);
-                inflightDataBlockReads.put(key, records);
-                DataBlockRecords finalRecords = records;
+            if (records != null) {
                 reader.read(blockIndex).whenComplete((dataBlock, ex) -> {
                     try (dataBlock) {
                         synchronized (inflightDataBlockReads) {
-                            inflightDataBlockReads.remove(key, finalRecords);
+                            inflightDataBlockReads.remove(key, records);
                         }
-                        finalRecords.complete(dataBlock, ex);
-                    } catch (Throwable e) {
-                        LOGGER.error("[UNEXPECTED] DataBlockRecords fail to notify listener {}", listener, e);
+                        records.complete(dataBlock, ex);
                     } finally {
-                        finalRecords.release();
+                        records.release();
                     }
                 });
-            } else {
-                records.registerListener(listener);
             }
         }
-        return cf;
+    }
+
+    public record ReserveResult(int reserveSize, CompletableFuture<DataBlockRecords> cf) {
     }
 }

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/InflightReadThrottle.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/InflightReadThrottle.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.cache;
+
+import com.automq.stream.s3.metrics.stats.BlockCacheMetricsStats;
+import com.automq.stream.s3.operator.DefaultS3Operator;
+import com.automq.stream.utils.ThreadUtils;
+import com.automq.stream.utils.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class InflightReadThrottle implements Runnable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InflightReadThrottle.class);
+    private static final Integer MAX_INFLIGHT_READ_SIZE = 256 * 1024 * 1024; //256MB
+    private final int maxInflightReadBytes;
+    private final Lock lock = new ReentrantLock();
+    private final Condition condition = lock.newCondition();
+    private final Map<UUID, Integer> inflightQuotaMap = new HashMap<>();
+    private final Queue<InflightReadItem> inflightReadQueue = new LinkedList<>();
+    private final ExecutorService executorService = Threads.newFixedThreadPool(1,
+            ThreadUtils.createThreadFactory("inflight-read-throttle-%d", false), LOGGER);
+
+    private int remainingInflightReadBytes;
+
+    public InflightReadThrottle() {
+        this((int) (MAX_INFLIGHT_READ_SIZE * DefaultS3Operator.MAX_MERGE_READ_SPARSITY_RATE));
+    }
+
+    public InflightReadThrottle(int maxInflightReadBytes) {
+        this.maxInflightReadBytes = maxInflightReadBytes;
+        this.remainingInflightReadBytes = maxInflightReadBytes;
+        executorService.execute(this);
+        BlockCacheMetricsStats.registerAvailableInflightReadSize(() -> {
+            lock.lock();
+            try {
+                return remainingInflightReadBytes;
+            } finally {
+                lock.unlock();
+            }
+        });
+    }
+
+    public void shutdown() {
+        executorService.shutdown();
+    }
+
+    public CompletableFuture<Void> acquire(UUID uuid, int readSize) {
+        lock.lock();
+        try {
+            if (readSize > maxInflightReadBytes) {
+                return CompletableFuture.failedFuture(new IllegalArgumentException(String.format(
+                        "read size %d exceeds max inflight read size %d", readSize, maxInflightReadBytes)));
+            }
+            if (readSize <= 0) {
+                return CompletableFuture.completedFuture(null);
+            }
+            inflightQuotaMap.put(uuid, readSize);
+            if (readSize <= remainingInflightReadBytes) {
+                remainingInflightReadBytes -= readSize;
+                return CompletableFuture.completedFuture(null);
+            }
+            CompletableFuture<Void> cf = new CompletableFuture<>();
+            inflightReadQueue.offer(new InflightReadItem(readSize, cf));
+            condition.signalAll();
+            return cf;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void release(UUID uuid) {
+        lock.lock();
+        try {
+            Integer inflightReadSize = inflightQuotaMap.remove(uuid);
+            if (inflightReadSize != null) {
+                remainingInflightReadBytes += inflightReadSize;
+                condition.signalAll();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void run() {
+        while (true) {
+            lock.lock();
+            try {
+                while (remainingInflightReadBytes <= 0 || inflightReadQueue.isEmpty()) {
+                    condition.await();
+                    if (!inflightReadQueue.isEmpty()) {
+                        InflightReadItem inflightReadItem = inflightReadQueue.peek();
+                        if (inflightReadItem.readSize < remainingInflightReadBytes) {
+                            break;
+                        }
+                    }
+                }
+                InflightReadItem inflightReadItem = inflightReadQueue.poll();
+                if (inflightReadItem == null) {
+                    continue;
+                }
+                remainingInflightReadBytes -= inflightReadItem.readSize;
+                inflightReadItem.cf.complete(null);
+            } catch (Exception e) {
+                break;
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    record InflightReadItem(int readSize, CompletableFuture<Void> cf) {
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/InflightReadThrottle.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/InflightReadThrottle.java
@@ -18,9 +18,9 @@
 package com.automq.stream.s3.cache;
 
 import com.automq.stream.s3.metrics.stats.BlockCacheMetricsStats;
-import com.automq.stream.s3.operator.DefaultS3Operator;
 import com.automq.stream.utils.ThreadUtils;
 import com.automq.stream.utils.Threads;
+import com.automq.stream.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +49,7 @@ public class InflightReadThrottle implements Runnable {
     private int remainingInflightReadBytes;
 
     public InflightReadThrottle() {
-        this((int) (MAX_INFLIGHT_READ_SIZE * DefaultS3Operator.MAX_MERGE_READ_SPARSITY_RATE));
+        this((int) (MAX_INFLIGHT_READ_SIZE * Utils.getMaxMergeReadSparsityRate()));
     }
 
     public InflightReadThrottle(int maxInflightReadBytes) {

--- a/s3stream/src/main/java/com/automq/stream/s3/cache/StreamReader.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/cache/StreamReader.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -50,6 +51,8 @@ public class StreamReader {
     private final ObjectReaderLRUCache objectReaders;
     private final DataBlockReadAccumulator dataBlockReadAccumulator;
     private final BlockCache blockCache;
+    private final Map<DefaultS3BlockCache.ReadAheadTaskKey, CompletableFuture<Void>> inflightReadAheadTaskMap;
+    private final InflightReadThrottle inflightReadThrottle;
     private final ExecutorService streamReaderExecutor = Threads.newFixedThreadPoolWithMonitor(
             2,
             "s3-stream-reader",
@@ -61,20 +64,33 @@ public class StreamReader {
             true,
             LOGGER);
 
-    public StreamReader(S3Operator operator, ObjectManager objectManager, BlockCache blockCache) {
+    public StreamReader(S3Operator operator, ObjectManager objectManager, BlockCache blockCache,
+                        Map<DefaultS3BlockCache.ReadAheadTaskKey, CompletableFuture<Void>> inflightReadAheadTaskMap,
+                        InflightReadThrottle inflightReadThrottle) {
         this.s3Operator = operator;
         this.objectManager = objectManager;
         this.objectReaders = new ObjectReaderLRUCache(MAX_OBJECT_READER_SIZE);
         this.dataBlockReadAccumulator = new DataBlockReadAccumulator();
         this.blockCache = blockCache;
+        this.inflightReadAheadTaskMap = inflightReadAheadTaskMap;
+        this.inflightReadThrottle = inflightReadThrottle;
     }
 
-    public CompletableFuture<List<StreamRecordBatch>> readAhead(long streamId, long startOffset, long endOffset, int maxBytes, ReadAheadAgent agent, boolean isAsync) {
+    public void shutdown() {
+        streamReaderExecutor.shutdown();
+        backgroundExecutor.shutdown();
+    }
+
+    public CompletableFuture<List<StreamRecordBatch>> syncReadAhead(long streamId, long startOffset, long endOffset,
+                                                                    int maxBytes, ReadAheadAgent agent, UUID uuid) {
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("[S3BlockCache] read ahead, stream={}, {}-{}, maxBytes={}, isAsync={}", streamId, startOffset, endOffset, maxBytes, isAsync);
+            LOGGER.debug("[S3BlockCache] sync read ahead, stream={}, {}-{}, maxBytes={}", streamId, startOffset, endOffset, maxBytes);
         }
         ReadContext context = new ReadContext(startOffset, maxBytes);
         TimerUtil timer = new TimerUtil();
+        DefaultS3BlockCache.ReadAheadTaskKey readAheadTaskKey = new DefaultS3BlockCache.ReadAheadTaskKey(streamId, startOffset);
+        // put a placeholder task at start offset to prevent next cache miss request spawn duplicated read ahead task
+        inflightReadAheadTaskMap.putIfAbsent(readAheadTaskKey, new CompletableFuture<>());
         return getDataBlockIndices(streamId, endOffset, context).thenComposeAsync(v -> {
             if (context.streamDataBlocksPair.isEmpty()) {
                 return CompletableFuture.completedFuture(Collections.emptyList());
@@ -83,68 +99,72 @@ public class StreamReader {
                 LOGGER.debug("[S3BlockCache] stream={}, {}-{}, read data block indices cost: {} ms", streamId, startOffset, endOffset,
                         timer.elapsedAs(TimeUnit.MILLISECONDS));
             }
-            // concurrently read all data blocks
-            //TODO: acquire quota single data block, so that they can be release on put block cache complete
+
             List<CompletableFuture<Void>> cfList = new ArrayList<>();
             Map<String, List<StreamRecordBatch>> recordsMap = new ConcurrentHashMap<>();
             List<String> sortedDataBlockKeyList = new ArrayList<>();
-            boolean firstDataBlock = true;
-            int totalSize = 0;
-            for (Pair<Long, List<StreamDataBlock>> entry : context.streamDataBlocksPair) {
-                long objectId = entry.getKey();
-                ObjectReader objectReader = context.objectReaderMap.get(objectId);
-                for (StreamDataBlock streamDataBlock : entry.getValue()) {
+
+            // collect all data blocks to read from S3
+            List<Pair<ObjectReader, StreamDataBlock>> streamDataBlocksToRead = collectStreamDataBlocksToRead(streamId, context);
+
+            // reserve all data blocks to read
+            List<DataBlockReadAccumulator.ReserveResult> reserveResults = dataBlockReadAccumulator.reserveDataBlock(streamDataBlocksToRead);
+            int totalReserveSize = reserveResults.stream().mapToInt(DataBlockReadAccumulator.ReserveResult::reserveSize).sum();
+
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("[S3BlockCache] sync ra acquire size: {}, uuid={}, stream={}, {}-{}, {}",
+                        totalReserveSize, uuid, streamId, startOffset, endOffset, maxBytes);
+            }
+
+            CompletableFuture<Void> throttleCf = inflightReadThrottle.acquire(uuid, totalReserveSize);
+            return throttleCf.thenComposeAsync(nil -> {
+                // concurrently read all data blocks
+                for (int i = 0; i < streamDataBlocksToRead.size(); i++) {
+                    Pair<ObjectReader, StreamDataBlock> pair = streamDataBlocksToRead.get(i);
+                    ObjectReader objectReader = pair.getLeft();
+                    StreamDataBlock streamDataBlock = pair.getRight();
                     if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug("[S3BlockCache] stream={}, {}-{}, read data block {} from {} [{}, {}), size={}",
+                        LOGGER.debug("[S3BlockCache] sync ra, stream={}, {}-{}, read data block {} from {} [{}, {}), size={}",
                                 streamId, startOffset, endOffset, streamDataBlock.getBlockId(), objectReader.objectKey(),
                                 streamDataBlock.getBlockStartPosition(), streamDataBlock.getBlockEndPosition(), streamDataBlock.getBlockSize());
                     }
-                    totalSize += streamDataBlock.getBlockSize();
-                    boolean finalFirstDataBlock = firstDataBlock;
-                    String dataBlockKey = objectId + "-" + streamDataBlock.getBlockId();
+                    String dataBlockKey = streamDataBlock.getObjectId() + "-" + streamDataBlock.getBlockId();
                     sortedDataBlockKeyList.add(dataBlockKey);
-                    cfList.add(dataBlockReadAccumulator.readDataBlock(objectReader, streamDataBlock.dataBlockIndex())
-                            .thenAcceptAsync(dataBlock -> {
-                                if (dataBlock.records().isEmpty()) {
-                                    return;
-                                }
+                    DataBlockReadAccumulator.ReserveResult reserveResult = reserveResults.get(i);
+                    DefaultS3BlockCache.ReadAheadTaskKey taskKey = new DefaultS3BlockCache.ReadAheadTaskKey(streamId, streamDataBlock.getStartOffset());
+                    cfList.add(reserveResult.cf().thenAcceptAsync(dataBlock -> {
+                        if (dataBlock.records().isEmpty()) {
+                            return;
+                        }
 
-                                if (!isAsync) {
-                                    // retain records to be returned
-                                    dataBlock.records().forEach(StreamRecordBatch::retain);
-                                    recordsMap.put(dataBlockKey, dataBlock.records());
-                                }
+                        // retain records to be returned
+                        dataBlock.records().forEach(StreamRecordBatch::retain);
+                        recordsMap.put(dataBlockKey, dataBlock.records());
 
-                                // retain records to be put into block cache
-                                dataBlock.records().forEach(StreamRecordBatch::retain);
-                                if (isAsync && finalFirstDataBlock) {
-                                    long firstOffset = dataBlock.records().get(0).getBaseOffset();
-                                    blockCache.put(streamId, firstOffset, context.lastOffset, dataBlock.records());
-                                } else {
-                                    blockCache.put(streamId, dataBlock.records());
-                                }
-                                dataBlock.release();
-                            }, backgroundExecutor));
-                    if (firstDataBlock) {
-                        firstDataBlock = false;
+                        // retain records to be put into block cache
+                        dataBlock.records().forEach(StreamRecordBatch::retain);
+                        blockCache.put(streamId, dataBlock.records());
+                        dataBlock.release();
+
+                        // complete and remove inflight read ahead task
+                        CompletableFuture<Void> inflightReadAheadTask = inflightReadAheadTaskMap.remove(taskKey);
+                        if (inflightReadAheadTask != null) {
+                            inflightReadAheadTask.complete(null);
+                        }
+                    }, backgroundExecutor));
+                    if (reserveResult.reserveSize() > 0) {
+                        dataBlockReadAccumulator.readDataBlock(objectReader, streamDataBlock.dataBlockIndex());
                     }
                 }
-            }
+                return CompletableFuture.allOf(cfList.toArray(CompletableFuture[]::new)).thenApply(vv -> {
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("[S3BlockCache] sync read ahead complete, stream={}, {}-{}, maxBytes: {}, " +
+                                        "result: {}-{}, {}, cost: {} ms", streamId, startOffset, endOffset, maxBytes,
+                                startOffset, context.lastOffset, context.totalReadSize, timer.elapsedAs(TimeUnit.MILLISECONDS));
+                    }
+                    context.releaseReader();
 
-            int finalTotalSize = totalSize;
-            return CompletableFuture.allOf(cfList.toArray(CompletableFuture[]::new)).thenApply(vv -> {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("[S3BlockCache] read data from s3 complete, stream={}, {}-{}, cost: {} ms", streamId, startOffset, endOffset,
-                             timer.elapsedAs(TimeUnit.MILLISECONDS));
-                }
-                // release all ObjectReaders
-                for (Map.Entry<Long, ObjectReader> entry : context.objectReaderMap.entrySet()) {
-                    entry.getValue().release();
-                }
-                context.objectReaderMap.clear();
-
-                List<StreamRecordBatch> recordsToReturn = new LinkedList<>();
-                if (!isAsync) {
+                    List<StreamRecordBatch> recordsToReturn = new LinkedList<>();
                     List<StreamRecordBatch> totalRecords = new ArrayList<>();
                     for (String dataBlockKey : sortedDataBlockKeyList) {
                         List<StreamRecordBatch> recordList = recordsMap.get(dataBlockKey);
@@ -166,9 +186,91 @@ public class StreamReader {
                     long lastReadOffset = recordsToReturn.isEmpty() ? totalRecords.get(0).getBaseOffset()
                             : recordsToReturn.get(recordsToReturn.size() - 1).getLastOffset();
                     blockCache.setReadAheadRecord(streamId, lastReadOffset, context.lastOffset);
+                    agent.updateReadAheadResult(context.lastOffset, context.totalReadSize);
+                    return recordsToReturn;
+                });
+            }, streamReaderExecutor);
+        }, streamReaderExecutor);
+    }
+
+    public void asyncReadAhead(long streamId, long startOffset, long endOffset, int maxBytes, ReadAheadAgent agent) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("[S3BlockCache] async read ahead, stream={}, {}-{}, maxBytes={}", streamId, startOffset, endOffset, maxBytes);
+        }
+        ReadContext context = new ReadContext(startOffset, maxBytes);
+        TimerUtil timer = new TimerUtil();
+        DefaultS3BlockCache.ReadAheadTaskKey readAheadTaskKey = new DefaultS3BlockCache.ReadAheadTaskKey(streamId, startOffset);
+        // put a placeholder task at start offset to prevent next cache miss request spawn duplicated read ahead task
+        inflightReadAheadTaskMap.putIfAbsent(readAheadTaskKey, new CompletableFuture<>());
+        getDataBlockIndices(streamId, endOffset, context).thenAcceptAsync(v -> {
+            if (context.streamDataBlocksPair.isEmpty()) {
+                return;
+            }
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("[S3BlockCache] stream={}, {}-{}, read data block indices cost: {} ms", streamId, startOffset, endOffset,
+                        timer.elapsedAs(TimeUnit.MILLISECONDS));
+            }
+
+            List<CompletableFuture<Void>> cfList = new ArrayList<>();
+            // collect all data blocks to read from S3
+            List<Pair<ObjectReader, StreamDataBlock>> streamDataBlocksToRead = collectStreamDataBlocksToRead(streamId, context);
+
+            // concurrently read all data blocks
+            for (int i = 0; i < streamDataBlocksToRead.size(); i++) {
+                Pair<ObjectReader, StreamDataBlock> pair = streamDataBlocksToRead.get(i);
+                ObjectReader objectReader = pair.getLeft();
+                StreamDataBlock streamDataBlock = pair.getRight();
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("[S3BlockCache] async ra, stream={}, {}-{}, read data block {} from {} [{}, {}), size={}",
+                            streamId, startOffset, endOffset, streamDataBlock.getBlockId(), objectReader.objectKey(),
+                            streamDataBlock.getBlockStartPosition(), streamDataBlock.getBlockEndPosition(), streamDataBlock.getBlockSize());
                 }
-                agent.updateReadAheadResult(context.lastOffset, finalTotalSize);
-                return recordsToReturn;
+                UUID uuid = UUID.randomUUID();
+                DefaultS3BlockCache.ReadAheadTaskKey taskKey = new DefaultS3BlockCache.ReadAheadTaskKey(streamId, streamDataBlock.getStartOffset());
+                DataBlockReadAccumulator.ReserveResult reserveResult = dataBlockReadAccumulator.reserveDataBlock(List.of(pair)).get(0);
+                int readIndex = i;
+                cfList.add(reserveResult.cf().thenAcceptAsync(dataBlock -> {
+                    if (dataBlock.records().isEmpty()) {
+                        return;
+                    }
+
+                    // retain records to be put into block cache
+                    dataBlock.records().forEach(StreamRecordBatch::retain);
+                    if (readIndex == 0) {
+                        long firstOffset = dataBlock.records().get(0).getBaseOffset();
+                        blockCache.put(streamId, firstOffset, context.lastOffset, dataBlock.records());
+                    } else {
+                        blockCache.put(streamId, dataBlock.records());
+                    }
+                    dataBlock.release();
+                    inflightReadThrottle.release(uuid);
+
+                    // complete and remove inflight read ahead task
+                    CompletableFuture<Void> inflightReadAheadTask = inflightReadAheadTaskMap.remove(taskKey);
+                    if (inflightReadAheadTask != null) {
+                        inflightReadAheadTask.complete(null);
+                    }
+                }, backgroundExecutor));
+
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("[S3BlockCache] async ra acquire size: {}, uuid={}, stream={}, {}-{}, {}",
+                            reserveResult.reserveSize(), uuid, streamId, startOffset, endOffset, maxBytes);
+                }
+                if (reserveResult.reserveSize() > 0) {
+                    inflightReadThrottle.acquire(uuid, reserveResult.reserveSize()).thenAcceptAsync(nil -> {
+                        // read data block
+                        dataBlockReadAccumulator.readDataBlock(objectReader, streamDataBlock.dataBlockIndex());
+                    }, streamReaderExecutor);
+                }
+            }
+            CompletableFuture.allOf(cfList.toArray(CompletableFuture[]::new)).thenAccept(vv -> {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("[S3BlockCache] sync read ahead complete, stream={}, {}-{}, maxBytes: {}, " +
+                                    "result: {}-{}, {}, cost: {} ms", streamId, startOffset, endOffset, maxBytes,
+                            startOffset, context.lastOffset, context.totalReadSize, timer.elapsedAs(TimeUnit.MILLISECONDS));
+                }
+                context.releaseReader();
+                agent.updateReadAheadResult(context.lastOffset, context.totalReadSize);
             });
         }, streamReaderExecutor);
     }
@@ -203,6 +305,7 @@ public class StreamReader {
             context.objectReaderMap.put(objectMetadata.objectId(), reader);
             return reader.find(streamId, context.nextStartOffset, endOffset, context.nextMaxBytes);
         }, streamReaderExecutor);
+
         return findIndexCf.thenComposeAsync(findIndexResult -> {
             if (findIndexResult == null) {
                 return CompletableFuture.completedFuture(null);
@@ -216,6 +319,7 @@ public class StreamReader {
             long lastOffset = streamDataBlocks.get(streamDataBlocks.size() - 1).getEndOffset();
             context.lastOffset = Math.max(lastOffset, context.lastOffset);
             context.streamDataBlocksPair.add(new ImmutablePair<>(objectMetadata.objectId(), streamDataBlocks));
+            context.totalReadSize += streamDataBlocks.stream().mapToInt(StreamDataBlock::getBlockSize).sum();
             if (findIndexResult.isFulfilled()) {
                 return CompletableFuture.completedFuture(null);
             }
@@ -224,6 +328,20 @@ public class StreamReader {
             context.objectIndex++;
             return getDataBlockIndices(streamId, endOffset, context);
         }, streamReaderExecutor);
+    }
+
+    private List<Pair<ObjectReader, StreamDataBlock>> collectStreamDataBlocksToRead(long streamId, ReadContext context) {
+        List<Pair<ObjectReader, StreamDataBlock>> result = new ArrayList<>();
+        for (Pair<Long, List<StreamDataBlock>> entry : context.streamDataBlocksPair) {
+            long objectId = entry.getKey();
+            ObjectReader objectReader = context.objectReaderMap.get(objectId);
+            for (StreamDataBlock streamDataBlock : entry.getValue()) {
+                result.add(Pair.of(objectReader, streamDataBlock));
+                DefaultS3BlockCache.ReadAheadTaskKey taskKey = new DefaultS3BlockCache.ReadAheadTaskKey(streamId, streamDataBlock.getStartOffset());
+                inflightReadAheadTaskMap.putIfAbsent(taskKey, new CompletableFuture<>());
+            }
+        }
+        return result;
     }
 
     private ObjectReader getObjectReader(S3ObjectMetadata metadata) {
@@ -244,6 +362,7 @@ public class StreamReader {
         int objectIndex;
         long nextStartOffset;
         int nextMaxBytes;
+        int totalReadSize;
         long lastOffset;
 
         public ReadContext(long startOffset, int maxBytes) {
@@ -253,6 +372,13 @@ public class StreamReader {
             this.objectReaderMap = new HashMap<>();
             this.nextStartOffset = startOffset;
             this.nextMaxBytes = maxBytes;
+        }
+
+        public void releaseReader() {
+            for (Map.Entry<Long, ObjectReader> entry : objectReaderMap.entrySet()) {
+                entry.getValue().release();
+            }
+            objectReaderMap.clear();
         }
 
     }

--- a/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/BlockCacheMetricsStats.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/metrics/stats/BlockCacheMetricsStats.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.metrics.stats;
+
+import com.automq.stream.s3.metrics.Gauge;
+import com.automq.stream.s3.metrics.Histogram;
+import com.automq.stream.s3.metrics.NoopHistogram;
+import com.automq.stream.s3.metrics.S3StreamMetricsRegistry;
+
+import java.util.Collections;
+
+public class BlockCacheMetricsStats {
+    private static Histogram readAheadSizeHistogram = null;
+
+    public static Histogram getOrCreateReadAheadSizeHist() {
+        if (readAheadSizeHistogram == null) {
+            readAheadSizeHistogram = S3StreamMetricsRegistry.getMetricsGroup()
+                    .newHistogram("read_ahead_size", Collections.emptyMap());
+        }
+        return readAheadSizeHistogram == null ? new NoopHistogram() : readAheadSizeHistogram;
+    }
+
+    public static void registerAvailableInflightReadSize(Gauge gauge) {
+        S3StreamMetricsRegistry.getMetricsGroup().newGauge("available_inflight_read_size", Collections.emptyMap(), gauge);
+    }
+
+}

--- a/s3stream/src/main/java/com/automq/stream/utils/Utils.java
+++ b/s3stream/src/main/java/com/automq/stream/utils/Utils.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.utils;
+
+public class Utils {
+    public static final String MAX_MERGE_READ_SPARSITY_RATE_NAME = "MERGE_READ_SPARSITY_RATE";
+    public static float getMaxMergeReadSparsityRate() {
+        float rate;
+        try {
+            rate = Float.parseFloat(System.getenv(MAX_MERGE_READ_SPARSITY_RATE_NAME));
+        } catch (Exception e) {
+            rate = 0.5f;
+        }
+        return rate;
+    }
+}

--- a/s3stream/src/test/java/com/automq/stream/s3/DefaultS3BlockCacheTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/DefaultS3BlockCacheTest.java
@@ -89,7 +89,7 @@ public class DefaultS3BlockCacheTest {
                 metadata3
         )));
 
-        ReadDataBlock rst = s3BlockCache.read(233L, 11L, 60L, 10000).get(3, TimeUnit.SECONDS);
+        ReadDataBlock rst = s3BlockCache.read(233L, 11L, 60L, 10000).get(3000, TimeUnit.SECONDS);
         assertEquals(5, rst.getRecords().size());
         assertEquals(10, rst.getRecords().get(0).getBaseOffset());
         assertEquals(60, rst.getRecords().get(4).getLastOffset());

--- a/s3stream/src/test/java/com/automq/stream/s3/ObjectReaderTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/ObjectReaderTest.java
@@ -26,6 +26,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -82,7 +83,7 @@ public class ObjectReaderTest {
         streamRanges.writeInt(90);
         streamRanges.writeInt(2);
 
-        ObjectReader.IndexBlock indexBlock = new ObjectReader.IndexBlock(blocks, streamRanges);
+        ObjectReader.IndexBlock indexBlock = new ObjectReader.IndexBlock(Mockito.mock(S3ObjectMetadata.class), blocks, streamRanges);
 
         ObjectReader.FindIndexResult rst = indexBlock.find(1, 10, 300, 100000);
         assertTrue(rst.isFulfilled());

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/BlockCacheTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/BlockCacheTest.java
@@ -18,15 +18,11 @@
 package com.automq.stream.s3.cache;
 
 import com.automq.stream.s3.TestUtils;
-import com.automq.stream.s3.metrics.TimerUtil;
 import com.automq.stream.s3.model.StreamRecordBatch;
-import com.automq.stream.utils.Threads;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/BlockCacheTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/BlockCacheTest.java
@@ -123,37 +123,6 @@ public class BlockCacheTest {
     }
 
     @Test
-    @Timeout(5)
-    public void testBlockGet() throws InterruptedException {
-        BlockCache blockCache = createBlockCache();
-        BlockCache.GetCacheResult rst = blockCache.get(233L, 23L, 24L, BlockCache.BLOCK_SIZE * 2);
-        List<StreamRecordBatch> records = rst.getRecords();
-        assertEquals(1, records.size());
-        assertEquals(23L, records.get(0).getBaseOffset());
-
-        TimerUtil timerUtil = new TimerUtil();
-        Thread t1 = new Thread(() -> {
-            BlockCache.GetCacheResult rst2 = blockCache.get(233L, 24L, 25L, BlockCache.BLOCK_SIZE * 2, true);
-            List<StreamRecordBatch> records2 = rst2.getRecords();
-            assertEquals(1, records2.size());
-            assertEquals(24L, records2.get(0).getBaseOffset());
-            assertEquals(1000, timerUtil.elapsedAs(TimeUnit.MILLISECONDS), 50);
-        });
-        t1.start();
-
-        Thread t2 = new Thread(() -> {
-            Threads.sleep(1000);
-            blockCache.put(233L, List.of(
-                    newRecord(233L, 24L, 6, 5)
-            ));
-        });
-        t2.start();
-
-        t1.join();
-        t2.join();
-    }
-
-    @Test
     public void testEvict() {
         BlockCache blockCache = new BlockCache(4);
         blockCache.put(233L, List.of(

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/InflightReadThrottleTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/InflightReadThrottleTest.java
@@ -17,6 +17,7 @@
 
 package com.automq.stream.s3.cache;
 
+import com.automq.stream.utils.Threads;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -29,11 +30,16 @@ public class InflightReadThrottleTest {
         InflightReadThrottle throttle = new InflightReadThrottle(1024);
         UUID uuid = UUID.randomUUID();
         CompletableFuture<Void> cf = throttle.acquire(uuid, 512);
+        Assertions.assertEquals(512, throttle.getRemainingInflightReadBytes());
         Assertions.assertTrue(cf.isDone());
         UUID uuid2 = UUID.randomUUID();
         CompletableFuture<Void> cf2 = throttle.acquire(uuid2, 600);
+        Assertions.assertEquals(512, throttle.getRemainingInflightReadBytes());
+        Assertions.assertEquals(1, throttle.getInflightQueueSize());
         Assertions.assertFalse(cf2.isDone());
         throttle.release(uuid);
+        Threads.sleep(1000);
+        Assertions.assertEquals(424, throttle.getRemainingInflightReadBytes());
         Assertions.assertTrue(cf2.isDone());
     }
 }

--- a/s3stream/src/test/java/com/automq/stream/s3/cache/InflightReadThrottleTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/cache/InflightReadThrottleTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.cache;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class InflightReadThrottleTest {
+    @Test
+    public void testThrottle() {
+        InflightReadThrottle throttle = new InflightReadThrottle(1024);
+        UUID uuid = UUID.randomUUID();
+        CompletableFuture<Void> cf = throttle.acquire(uuid, 512);
+        Assertions.assertTrue(cf.isDone());
+        UUID uuid2 = UUID.randomUUID();
+        CompletableFuture<Void> cf2 = throttle.acquire(uuid2, 600);
+        Assertions.assertFalse(cf2.isDone());
+        throttle.release(uuid);
+        Assertions.assertTrue(cf2.isDone());
+    }
+}


### PR DESCRIPTION
1. limit inflight memory consumption for read ahead
2. async wait for inflight read ahead task completion instead of blocking wait