### PR TITLE
fix(s3Stream): support aliyun oss

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <guava.version>32.1.3-jre</guava.version>
         <slf4j.version>2.0.9</slf4j.version>
         <snakeyaml.version>2.2</snakeyaml.version>
-        <s3stream.version>0.6.8-SNAPSHOT</s3stream.version>
+        <s3stream.version>0.6.9-SNAPSHOT</s3stream.version>
 
         <!-- Flat buffers related -->
         <flatbuffers.version>23.5.26</flatbuffers.version>

--- a/s3stream/pom.xml
+++ b/s3stream/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.automq.elasticstream</groupId>
     <artifactId>s3stream</artifactId>
-    <version>0.6.8-SNAPSHOT</version>
+    <version>0.6.9-SNAPSHOT</version>
     <properties>
         <mockito-core.version>5.5.0</mockito-core.version>
         <junit-jupiter.version>5.10.0</junit-jupiter.version>

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/DefaultS3Operator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/DefaultS3Operator.java
@@ -566,8 +566,8 @@ public class DefaultS3Operator implements S3Operator {
 
     private void checkAvailable() {
         byte[] content = new Date().toString().getBytes(StandardCharsets.UTF_8);
-        String path = String.format("/check_available/%d", System.currentTimeMillis());
-        String multipartPath = String.format("/check_available_multipart/%d", System.currentTimeMillis());
+        String path = String.format("check_available/%d", System.currentTimeMillis());
+        String multipartPath = String.format("check_available_multipart/%d", System.currentTimeMillis());
         try {
             // Simple write/read/delete
             this.write(path, Unpooled.wrappedBuffer(content)).get(30, TimeUnit.SECONDS);

--- a/s3stream/src/main/java/com/automq/stream/s3/operator/S3Operator.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/operator/S3Operator.java
@@ -46,7 +46,7 @@ public interface S3Operator {
     /**
      * Write data to object.
      *
-     * @param path object path.
+     * @param path object path. The path should not start with '/' since Aliyun OSS does not support it.
      * @param data data.
      * @param throttleStrategy throttle strategy.
      */


### PR DESCRIPTION
This pull request aims to resolve compatibility issues when running the S3 stream on Aliyun OSS.

Currently, the AWS SDK throws an exception with the message "The request signature we calculated does not match the signature you provided." It appears that Aliyun OSS does not support paths starting with '/'. A similar issue can be referred [here](https://stackoverflow.com/questions/57170720/aws-s3-the-request-signature-we-calculated-does-not-match-the-signature-you-pro). Perhaps Aliyun has not fixed this particular issue.