### PR TITLE
perf(s3stream): use read lock rather than write lock in append

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -800,7 +800,7 @@ public class S3Storage implements Storage {
                 return Collections.emptyList();
             }
 
-            List<WalWriteRequest> rst = new ArrayList<>();
+            LinkedList<WalWriteRequest> rst = new LinkedList<>();
             WalWriteRequest poll = streamRequests.poll();
             assert poll == peek;
             rst.add(poll);
@@ -812,6 +812,7 @@ public class S3Storage implements Storage {
                 }
                 poll = streamRequests.poll();
                 assert poll == peek;
+                assert poll.record.getBaseOffset() == rst.getLast().record.getLastOffset();
                 rst.add(poll);
             }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -471,7 +471,13 @@ public class S3Storage implements Storage {
     }
 
     private void handleAppendRequest(WalWriteRequest request) {
-        callbackSequencer.before(request);
+        Lock lock = getStreamCallbackLock(request.record.getStreamId());
+        lock.lock();
+        try {
+            callbackSequencer.before(request);
+        } finally {
+            lock.unlock();
+        }
     }
 
     private void handleAppendCallback(WalWriteRequest request) {

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Storage.java
@@ -89,7 +89,7 @@ public class S3Storage implements Storage {
      */
     private final LogCache deltaWALCache;
     /**
-     * WAL out of order callback sequencer. {@link #streamCallbackLocks} will ensure the memory safety.
+     * WAL out of order callback sequencer. {@link #callbackSequencerLocks} will ensure the memory safety.
      */
     private final WALCallbackSequencer callbackSequencer = new WALCallbackSequencer();
     private final WALConfirmOffsetCalculator confirmOffsetCalculator = new WALConfirmOffsetCalculator();
@@ -113,11 +113,12 @@ public class S3Storage implements Storage {
     private final S3Operator s3Operator;
     private final S3BlockCache blockCache;
     /**
-     * Stream callback locks. Used to ensure the stream callbacks will not be called concurrently.
+     * Stream callback locks. Used to ensure the stream requests and callbacks will not be called concurrently.
      *
+     * @see #handleAppendRequest
      * @see #handleAppendCallback
      */
-    private final Lock[] streamCallbackLocks = IntStream.range(0, NUM_STREAM_CALLBACK_LOCKS).mapToObj(i -> new ReentrantLock()).toArray(Lock[]::new);
+    private final Lock[] callbackSequencerLocks = IntStream.range(0, NUM_STREAM_CALLBACK_LOCKS).mapToObj(i -> new ReentrantLock()).toArray(Lock[]::new);
     private final HashedWheelTimer timeoutDetect = new HashedWheelTimer(
         ThreadUtils.createThreadFactory("storage-timeout-detect", true), 1, TimeUnit.SECONDS, 100);
     private long lastLogTimestamp = 0L;
@@ -273,11 +274,21 @@ public class S3Storage implements Storage {
     public CompletableFuture<Void> append(AppendContext context, StreamRecordBatch streamRecord) {
         TimerUtil timerUtil = new TimerUtil();
         CompletableFuture<Void> cf = new CompletableFuture<>();
+
         // encoded before append to free heap ByteBuf.
         streamRecord.encoded();
+
         WalWriteRequest writeRequest = new WalWriteRequest(streamRecord, -1L, cf, context);
-        handleAppendRequest(writeRequest);
-        append0(context, writeRequest, false);
+        // lock it to make sure requests are added into {@link #callbackSequencer} in the same order as they sent to deltaWAL.
+        Lock lock = callbackSequencerLock(writeRequest.record.getStreamId());
+        lock.lock();
+        try {
+            handleAppendRequest(writeRequest);
+            append0(context, writeRequest, false);
+        } finally {
+            lock.unlock();
+        }
+
         cf.whenComplete((nil, ex) -> {
             streamRecord.release();
             S3StreamMetricsManager.recordOperationLatency(MetricsLevel.INFO, timerUtil.elapsedAs(TimeUnit.NANOSECONDS), S3Operation.APPEND_STORAGE);
@@ -471,13 +482,7 @@ public class S3Storage implements Storage {
     }
 
     private void handleAppendRequest(WalWriteRequest request) {
-        Lock lock = getStreamCallbackLock(request.record.getStreamId());
-        lock.lock();
-        try {
-            callbackSequencer.before(request);
-        } finally {
-            lock.unlock();
-        }
+        callbackSequencer.before(request);
     }
 
     private void handleAppendCallback(WalWriteRequest request) {
@@ -487,7 +492,7 @@ public class S3Storage implements Storage {
     private void handleAppendCallback0(WalWriteRequest request) {
         TimerUtil timer = new TimerUtil();
         List<WalWriteRequest> waitingAckRequests;
-        Lock lock = getStreamCallbackLock(request.record.getStreamId());
+        Lock lock = callbackSequencerLock(request.record.getStreamId());
         lock.lock();
         try {
             waitingAckRequests = callbackSequencer.after(request);
@@ -507,8 +512,8 @@ public class S3Storage implements Storage {
         S3StreamMetricsManager.recordOperationLatency(MetricsLevel.DEBUG, timer.elapsedAs(TimeUnit.NANOSECONDS), S3Operation.APPEND_STORAGE_APPEND_CALLBACK);
     }
 
-    private Lock getStreamCallbackLock(long streamId) {
-        return streamCallbackLocks[(int) ((streamId & Long.MAX_VALUE) % NUM_STREAM_CALLBACK_LOCKS)];
+    private Lock callbackSequencerLock(long streamId) {
+        return callbackSequencerLocks[(int) ((streamId & Long.MAX_VALUE) % NUM_STREAM_CALLBACK_LOCKS)];
     }
 
     @SuppressWarnings("UnusedReturnValue")

--- a/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/S3Stream.java
@@ -134,7 +134,7 @@ public class S3Stream implements Stream {
     @WithSpan
     public CompletableFuture<AppendResult> append(AppendContext context, RecordBatch recordBatch) {
         TimerUtil timerUtil = new TimerUtil();
-        writeLock.lock();
+        readLock.lock();
         S3StreamMetricsManager.recordOperationLatency(MetricsLevel.DEBUG, timerUtil.elapsedAs(TimeUnit.NANOSECONDS), S3Operation.APPEND_STREAM_WRITE_LOCK);
         try {
             CompletableFuture<AppendResult> cf = exec(() -> {
@@ -150,7 +150,7 @@ public class S3Stream implements Stream {
             });
             return cf;
         } finally {
-            writeLock.unlock();
+            readLock.unlock();
         }
     }
 


### PR DESCRIPTION
part of https://github.com/AutoMQ/automq-for-kafka/issues/621