### PR TITLE
perf(s3stream): speedup wal recovery

### DIFF
--- a/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
@@ -25,6 +25,7 @@ import com.automq.stream.s3.metrics.TimerUtil;
 import com.automq.stream.s3.metrics.stats.StorageOperationStats;
 import com.automq.stream.s3.trace.TraceUtils;
 import com.automq.stream.s3.trace.context.TraceContext;
+import com.automq.stream.s3.wal.util.WALCachedChannel;
 import com.automq.stream.s3.wal.util.WALChannel;
 import com.automq.stream.s3.wal.util.WALUtil;
 import com.automq.stream.utils.ThreadUtils;
@@ -136,6 +137,9 @@ public class BlockWALService implements WriteAheadLog {
 
     public static BlockWALServiceBuilder recoveryBuilder(String path) {
         return new BlockWALServiceBuilder(path);
+    }
+
+    private BlockWALService() {
     }
 
     private void flushWALHeader(ShutdownType shutdownType) throws IOException {
@@ -661,9 +665,10 @@ public class BlockWALService implements WriteAheadLog {
             if (direct != null) {
                 walChannelBuilder.direct(direct);
             }
-            blockWALService.walChannel = walChannelBuilder.build();
+            WALChannel channel = walChannelBuilder.build();
+            blockWALService.walChannel = WALCachedChannel.of(channel);
             if (!blockWALService.walChannel.useDirectIO()) {
-                LOGGER.info("block wal not using direct IO");
+                LOGGER.warn("block wal not using direct IO");
             }
 
             if (!recoveryMode) {
@@ -673,7 +678,7 @@ public class BlockWALService implements WriteAheadLog {
                 slidingWindowUpperLimit = Math.min(slidingWindowUpperLimit, blockDeviceCapacityWant - WAL_HEADER_TOTAL_CAPACITY);
                 blockWALService.initialWindowSize = slidingWindowInitialSize;
                 blockWALService.slidingWindowService = new SlidingWindowService(
-                    blockWALService.walChannel,
+                    channel,
                     ioThreadNums,
                     slidingWindowUpperLimit,
                     slidingWindowScaleUnit,

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
@@ -171,8 +171,6 @@ public class BlockWALService implements WriteAheadLog {
      */
     private ByteBuf readRecord(long recoverStartOffset,
         Function<Long, Long> logicalToPhysical) throws ReadRecordException {
-        // TODO: a cache wrapper of WALChannel
-        // release related resources in the finally block
         final ByteBuf recordHeader = DirectByteBufAlloc.byteBuffer(RECORD_HEADER_SIZE);
         SlidingWindowService.RecordHeaderCoreData readRecordHeader;
         try {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
@@ -167,6 +167,8 @@ public class BlockWALService implements WriteAheadLog {
      */
     private ByteBuf readRecord(long recoverStartOffset,
         Function<Long, Long> logicalToPhysical) throws ReadRecordException {
+        // TODO: a cache wrapper of WALChannel
+        // release related resources in the finally block
         final ByteBuf recordHeader = DirectByteBufAlloc.byteBuffer(RECORD_HEADER_SIZE);
         SlidingWindowService.RecordHeaderCoreData readRecordHeader;
         try {
@@ -740,10 +742,12 @@ public class BlockWALService implements WriteAheadLog {
 
         @Override
         public boolean equals(Object obj) {
-            if (obj == this)
+            if (obj == this) {
                 return true;
-            if (obj == null || obj.getClass() != this.getClass())
+            }
+            if (obj == null || obj.getClass() != this.getClass()) {
                 return false;
+            }
             var that = (AppendResultImpl) obj;
             return this.recordOffset == that.recordOffset &&
                 Objects.equals(this.future, that.future);
@@ -785,10 +789,12 @@ public class BlockWALService implements WriteAheadLog {
 
         @Override
         public boolean equals(Object obj) {
-            if (obj == this)
+            if (obj == this) {
                 return true;
-            if (obj == null || obj.getClass() != this.getClass())
+            }
+            if (obj == null || obj.getClass() != this.getClass()) {
                 return false;
+            }
             var that = (RecoverResultImpl) obj;
             return Objects.equals(this.record, that.record) &&
                 this.recordOffset == that.recordOffset;

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/BlockWALService.java
@@ -118,7 +118,7 @@ public class BlockWALService implements WriteAheadLog {
     private final AtomicLong writeHeaderRoundTimes = new AtomicLong(0);
     private final ExecutorService walHeaderFlusher = Threads.newFixedThreadPool(1, ThreadUtils.createThreadFactory("flush-wal-header-thread-%d", true), LOGGER);
     private long initialWindowSize;
-    private WALChannel walChannel;
+    private WALCachedChannel walChannel;
     private SlidingWindowService slidingWindowService;
     private WALHeader walHeader;
     private boolean recoveryMode;
@@ -844,6 +844,7 @@ public class BlockWALService implements WriteAheadLog {
             if (!hasNext) {
                 // recovery complete
                 recoveryCompleteOffset = WALUtil.alignLargeByBlockSize(nextRecoverOffset);
+                walChannel.releaseCache();
             }
             return hasNext;
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/BenchTool.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/BenchTool.java
@@ -32,9 +32,8 @@ import net.sourceforge.argparse4j.inf.Namespace;
 
 public class BenchTool {
 
-    public static Namespace parseArgs(String[] args) {
+    public static Namespace parseArgs(ArgumentParser parser, String[] args) {
         Namespace ns = null;
-        ArgumentParser parser = WriteBench.Config.parser();
         try {
             ns = parser.parseArgs(args);
         } catch (HelpScreenException e) {

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/BenchTool.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/BenchTool.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.wal.benchmark;
+
+import com.automq.stream.s3.DirectByteBufAlloc;
+import com.automq.stream.s3.wal.BlockWALService;
+import com.automq.stream.s3.wal.WriteAheadLog;
+import com.automq.stream.s3.wal.util.WALChannel;
+import io.netty.buffer.ByteBuf;
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+import net.sourceforge.argparse4j.helper.HelpScreenException;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.Namespace;
+
+public class BenchTool {
+
+    public static Namespace parseArgs(String[] args) {
+        Namespace ns = null;
+        ArgumentParser parser = WriteBench.Config.parser();
+        try {
+            ns = parser.parseArgs(args);
+        } catch (HelpScreenException e) {
+            System.exit(0);
+        } catch (ArgumentParserException e) {
+            parser.handleError(e);
+            System.exit(1);
+        }
+        return ns;
+    }
+
+    public static int recoverAndReset(WriteAheadLog wal) {
+        int recovered = 0;
+        for (Iterator<WriteAheadLog.RecoverResult> it = wal.recover(); it.hasNext(); ) {
+            it.next().record().release();
+            recovered++;
+        }
+        wal.reset().join();
+        return recovered;
+    }
+
+    public static void resetWALHeader(String path) throws IOException {
+        System.out.println("Resetting WAL header");
+        if (path.startsWith(WALChannel.DEVICE_PREFIX)) {
+            // block device
+            int capacity = BlockWALService.WAL_HEADER_TOTAL_CAPACITY;
+            WALChannel channel = WALChannel.builder(path).capacity(capacity).build();
+            channel.open();
+            ByteBuf buf = DirectByteBufAlloc.byteBuffer(capacity);
+            buf.writeZero(capacity);
+            channel.write(buf, 0);
+            buf.release();
+            channel.close();
+        } else {
+            // normal file
+            File file = new File(path);
+            if (file.isFile() && !file.delete()) {
+                throw new IOException("Failed to delete existing file " + file);
+            }
+        }
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/RecoveryBench.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/RecoveryBench.java
@@ -47,7 +47,7 @@ public class RecoveryBench implements AutoCloseable {
     }
 
     public static void main(String[] args) throws Exception {
-        Namespace ns = parseArgs(args);
+        Namespace ns = parseArgs(Config.parser(), args);
         Config config = new Config(ns);
 
         resetWALHeader(config.path);

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/RecoveryBench.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/RecoveryBench.java
@@ -69,7 +69,7 @@ public class RecoveryBench implements AutoCloseable {
 
         AtomicInteger appended = new AtomicInteger();
         for (int i = 0; i < numRecords; i++) {
-            WriteAheadLog.AppendResult result = log.append(payload);
+            WriteAheadLog.AppendResult result = log.append(payload.retainedDuplicate());
             result.future().whenComplete((r, e) -> {
                 if (e != null) {
                     System.err.println("Failed to append record: " + e.getMessage());

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/RecoveryBench.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/RecoveryBench.java
@@ -124,11 +124,11 @@ public class RecoveryBench implements AutoCloseable {
                 .type(Long.class)
                 .setDefault((long) 3 << 30)
                 .help("Capacity of the WAL in bytes");
-            parser.addArgument("--numRecords")
+            parser.addArgument("--records")
                 .type(Integer.class)
                 .setDefault(1 << 20)
                 .help("number of records to write");
-            parser.addArgument("--recordSizeBytes")
+            parser.addArgument("--record-size")
                 .type(Integer.class)
                 .setDefault(1 << 10)
                 .help("size of each record in bytes");

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/RecoveryBench.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/RecoveryBench.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.wal.benchmark;
+
+import com.automq.stream.s3.wal.BlockWALService;
+import com.automq.stream.s3.wal.WriteAheadLog;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.commons.lang3.time.StopWatch;
+
+import static com.automq.stream.s3.wal.benchmark.BenchTool.parseArgs;
+import static com.automq.stream.s3.wal.benchmark.BenchTool.recoverAndReset;
+import static com.automq.stream.s3.wal.benchmark.BenchTool.resetWALHeader;
+
+/**
+ * RecoveryBench is a tool to benchmark the recovery performance of {@link BlockWALService}
+ */
+public class RecoveryBench implements AutoCloseable {
+
+    private final WriteAheadLog log;
+    private Random random = new Random();
+
+    public RecoveryBench(Config config) throws IOException {
+        this.log = BlockWALService.builder(config.path, config.capacity).build().start();
+        recoverAndReset(log);
+    }
+
+    public static void main(String[] args) throws Exception {
+        Namespace ns = parseArgs(args);
+        Config config = new Config(ns);
+
+        resetWALHeader(config.path);
+        try (RecoveryBench bench = new RecoveryBench(config)) {
+            bench.run(config);
+        }
+    }
+
+    private void run(Config config) throws Exception {
+        writeRecords(config.numRecords, config.recordSizeBytes);
+        recoverRecords(config.path);
+    }
+
+    private void writeRecords(int numRecords, int recordSizeBytes) throws WriteAheadLog.OverCapacityException {
+        System.out.println("Writing " + numRecords + " records of size " + recordSizeBytes + " bytes");
+        byte[] bytes = new byte[recordSizeBytes];
+        random.nextBytes(bytes);
+        ByteBuf payload = Unpooled.wrappedBuffer(bytes).retain();
+
+        AtomicInteger appended = new AtomicInteger();
+        for (int i = 0; i < numRecords; i++) {
+            WriteAheadLog.AppendResult result = log.append(payload);
+            result.future().whenComplete((r, e) -> {
+                if (e != null) {
+                    System.err.println("Failed to append record: " + e.getMessage());
+                    e.printStackTrace();
+                } else {
+                    appended.incrementAndGet();
+                }
+            });
+        }
+        System.out.println("Appended " + appended.get() + " records (may not be the final number)");
+    }
+
+    private void recoverRecords(String path) throws IOException {
+        System.out.println("Recovering records from " + path);
+        WriteAheadLog recoveryLog = BlockWALService.recoveryBuilder(path).build().start();
+        StopWatch stopWatch = StopWatch.createStarted();
+        int recovered = recoverAndReset(recoveryLog);
+        System.out.println("Recovered " + recovered + " records in " + stopWatch.getTime() + " ms");
+    }
+
+    @Override
+    public void close() {
+        log.shutdownGracefully();
+    }
+
+    static class Config {
+        // following fields are WAL configuration
+        final String path;
+        final Long capacity;
+
+        // following fields are benchmark configuration
+        final Integer numRecords;
+        final Integer recordSizeBytes;
+
+        Config(Namespace ns) {
+            this.path = ns.getString("path");
+            this.capacity = ns.getLong("capacity");
+            this.numRecords = ns.getInt("numRecords");
+            this.recordSizeBytes = ns.getInt("recordSizeBytes");
+        }
+
+        static ArgumentParser parser() {
+            ArgumentParser parser = ArgumentParsers
+                .newFor("RecoveryBench")
+                .build()
+                .defaultHelp(true)
+                .description("Benchmark the recovery performance of BlockWALService");
+            parser.addArgument("-p", "--path")
+                .required(true)
+                .help("Path of the WAL file");
+            parser.addArgument("-c", "--capacity")
+                .type(Long.class)
+                .setDefault((long) 3 << 30)
+                .help("Capacity of the WAL in bytes");
+            parser.addArgument("--numRecords")
+                .type(Integer.class)
+                .setDefault(1 << 20)
+                .help("number of records to write");
+            parser.addArgument("--recordSizeBytes")
+                .type(Integer.class)
+                .setDefault(1 << 10)
+                .help("size of each record in bytes");
+            return parser;
+        }
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/WriteBench.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/WriteBench.java
@@ -17,19 +17,14 @@
 
 package com.automq.stream.s3.wal.benchmark;
 
-import com.automq.stream.s3.DirectByteBufAlloc;
 import com.automq.stream.s3.wal.BlockWALService;
 import com.automq.stream.s3.wal.WriteAheadLog;
-import com.automq.stream.s3.wal.util.WALChannel;
 import com.automq.stream.utils.ThreadUtils;
 import com.automq.stream.utils.Threads;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.NavigableSet;
-import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutorService;
@@ -40,10 +35,12 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 import net.sourceforge.argparse4j.ArgumentParsers;
-import net.sourceforge.argparse4j.helper.HelpScreenException;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
-import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
+
+import static com.automq.stream.s3.wal.benchmark.BenchTool.parseArgs;
+import static com.automq.stream.s3.wal.benchmark.BenchTool.recoverAndReset;
+import static com.automq.stream.s3.wal.benchmark.BenchTool.resetWALHeader;
 
 /**
  * WriteBench is a tool for benchmarking write performance of {@link BlockWALService}
@@ -65,49 +62,16 @@ public class WriteBench implements AutoCloseable {
         }
         this.log = builder.build();
         this.log.start();
-        for (Iterator<WriteAheadLog.RecoverResult> it = this.log.recover(); it.hasNext(); ) {
-            it.next().record().release();
-        }
-        this.log.reset().join();
+        recoverAndReset(this.log);
     }
 
     public static void main(String[] args) throws IOException {
-        Namespace ns = null;
-        ArgumentParser parser = Config.parser();
-        try {
-            ns = parser.parseArgs(args);
-        } catch (HelpScreenException e) {
-            System.exit(0);
-        } catch (ArgumentParserException e) {
-            parser.handleError(e);
-            System.exit(1);
-        }
+        Namespace ns = parseArgs(args);
         Config config = new Config(ns);
 
         resetWALHeader(config.path);
         try (WriteBench bench = new WriteBench(config)) {
             bench.run(config);
-        }
-    }
-
-    private static void resetWALHeader(String path) throws IOException {
-        System.out.println("Resetting WAL header");
-        if (path.startsWith(WALChannel.DEVICE_PREFIX)) {
-            // block device
-            int capacity = BlockWALService.WAL_HEADER_TOTAL_CAPACITY;
-            WALChannel channel = WALChannel.builder(path).capacity(capacity).build();
-            channel.open();
-            ByteBuf buf = DirectByteBufAlloc.byteBuffer(capacity);
-            buf.writeZero(capacity);
-            channel.write(buf, 0);
-            buf.release();
-            channel.close();
-        } else {
-            // normal file
-            File file = new File(path);
-            if (file.isFile() && !file.delete()) {
-                throw new IOException("Failed to delete existing file " + file);
-            }
         }
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/WriteBench.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/WriteBench.java
@@ -357,34 +357,6 @@ public class WriteBench implements AutoCloseable {
             public long elapsedTimeNanos() {
                 return elapsedTimeNanos;
             }
-
-            @Override
-            public boolean equals(Object obj) {
-                if (obj == this)
-                    return true;
-                if (obj == null || obj.getClass() != this.getClass())
-                    return false;
-                var that = (Result) obj;
-                return this.count == that.count &&
-                    this.costNanos == that.costNanos &&
-                    this.maxCostNanos == that.maxCostNanos &&
-                    this.elapsedTimeNanos == that.elapsedTimeNanos;
-            }
-
-            @Override
-            public int hashCode() {
-                return Objects.hash(count, costNanos, maxCostNanos, elapsedTimeNanos);
-            }
-
-            @Override
-            public String toString() {
-                return "Result[" +
-                    "count=" + count + ", " +
-                    "costNanos=" + costNanos + ", " +
-                    "maxCostNanos=" + maxCostNanos + ", " +
-                    "elapsedTimeNanos=" + elapsedTimeNanos + ']';
-            }
-
         }
     }
 

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/WriteBench.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/benchmark/WriteBench.java
@@ -66,7 +66,7 @@ public class WriteBench implements AutoCloseable {
     }
 
     public static void main(String[] args) throws IOException {
-        Namespace ns = parseArgs(args);
+        Namespace ns = parseArgs(Config.parser(), args);
         Config config = new Config(ns);
 
         resetWALHeader(config.path);

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
@@ -301,6 +301,7 @@ public class WALBlockDeviceChannel implements WALChannel {
         long alignedStart = WALUtil.alignSmallByBlockSize(start);
         long alignedEnd = WALUtil.alignLargeByBlockSize(end);
         int alignedSize = (int) (alignedEnd - alignedStart);
+        // capacity may be CAPACITY_NOT_SET only when we call {@link CapacityReader#capacity} in recovery mode
         assert CAPACITY_NOT_SET == capacity() || alignedEnd <= capacity();
 
         ByteBuffer tmpBuf = getBuffer(alignedSize);

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannel.java
@@ -295,9 +295,10 @@ public class WALBlockDeviceChannel implements WALChannel {
     }
 
     @Override
-    public int read(ByteBuf dst, long position) throws IOException {
+    public int read(ByteBuf dst, long position, int length) throws IOException {
         long start = position;
-        long end = position + dst.writableBytes();
+        length = Math.min(length, dst.writableBytes());
+        long end = position + length;
         long alignedStart = WALUtil.alignSmallByBlockSize(start);
         long alignedEnd = WALUtil.alignLargeByBlockSize(end);
         int alignedSize = (int) (alignedEnd - alignedStart);

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALCachedChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALCachedChannel.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.automq.stream.s3.wal.util;
+
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+
+/**
+ * A wrapper of {@link WALChannel} that caches for read to reduce I/O.
+ */
+public class WALCachedChannel implements WALChannel {
+
+    private static final int DEFAULT_CACHE_SIZE = 1 << 20;
+
+    private final WALChannel channel;
+    private final int cacheSize;
+
+    private WALCachedChannel(WALChannel channel, int cacheSize) {
+        this.channel = channel;
+        this.cacheSize = cacheSize;
+    }
+
+    public static WALCachedChannel of(WALChannel channel) {
+        return new WALCachedChannel(channel, DEFAULT_CACHE_SIZE);
+    }
+
+    public static WALCachedChannel of(WALChannel channel, int cacheSize) {
+        return new WALCachedChannel(channel, cacheSize);
+    }
+
+    @Override
+    public int read(ByteBuf dst, long position) throws IOException {
+        // TODO
+        return this.channel.read(dst, position);
+    }
+
+    @Override
+    public void open(CapacityReader reader) throws IOException {
+        this.channel.open(reader);
+    }
+
+    @Override
+    public void close() {
+        // TODO: maybe release cache
+        this.channel.close();
+    }
+
+    @Override
+    public long capacity() {
+        return this.channel.capacity();
+    }
+
+    @Override
+    public String path() {
+        return this.channel.path();
+    }
+
+    @Override
+    public void write(ByteBuf src, long position) throws IOException {
+        this.channel.write(src, position);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        this.channel.flush();
+    }
+}

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALCachedChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALCachedChannel.java
@@ -21,6 +21,8 @@ import com.automq.stream.s3.DirectByteBufAlloc;
 import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 
+import static com.automq.stream.s3.Constants.CAPACITY_NOT_SET;
+
 /**
  * A wrapper of {@link WALChannel} that caches for read to reduce I/O.
  */
@@ -52,6 +54,10 @@ public class WALCachedChannel implements WALChannel {
      */
     @Override
     public synchronized int read(ByteBuf dst, long position, int length) throws IOException {
+        if (CAPACITY_NOT_SET == channel.capacity()) {
+            // If we don't know the capacity now, we can't cache.
+            return channel.read(dst, position, length);
+        }
         long start = position;
         length = Math.min(length, dst.writableBytes());
         long end = position + length;

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
@@ -88,7 +88,19 @@ public interface WALChannel {
      * This method will change the writer index of the given buffer to the end of the read bytes.
      * This method will not change the reader index of the given buffer.
      */
-    int read(ByteBuf dst, long position) throws IOException;
+    default int read(ByteBuf dst, long position) throws IOException {
+        return read(dst, position, dst.writableBytes());
+    }
+
+    /**
+     * Read bytes from the given position of the channel to the given buffer from the current writer index
+     * until reaching the given length or the end of the channel.
+     * This method will change the writer index of the given buffer to the end of the read bytes.
+     * This method will not change the reader index of the given buffer.
+     * If the given length is larger than the writable bytes of the given buffer, only the first
+     * {@code dst.writableBytes()} bytes will be read.
+     */
+    int read(ByteBuf dst, long position, int length) throws IOException;
 
     default boolean useDirectIO() {
         return this instanceof WALBlockDeviceChannel;

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALChannel.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.automq.stream.s3.Constants.CAPACITY_NOT_SET;
+
 /**
  * There are two implementations of WALChannel:
  * 1. WALFileChannel based on file system, which calls fsync after each write to ensure data is flushed to disk.
@@ -119,6 +121,7 @@ public interface WALChannel {
         }
 
         public WALChannelBuilder capacity(long capacity) {
+            assert capacity == CAPACITY_NOT_SET || WALUtil.isAligned(capacity);
             this.capacity = capacity;
             return this;
         }

--- a/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALFileChannel.java
+++ b/s3stream/src/main/java/com/automq/stream/s3/wal/util/WALFileChannel.java
@@ -128,11 +128,12 @@ public class WALFileChannel implements WALChannel {
     }
 
     @Override
-    public int read(ByteBuf dst, long position) throws IOException {
-        assert dst.writableBytes() + position <= capacity();
+    public int read(ByteBuf dst, long position, int length) throws IOException {
+        length = Math.min(length, dst.writableBytes());
+        assert position + length <= capacity();
         int bytesRead = 0;
         while (dst.isWritable()) {
-            int read = dst.writeBytes(fileChannel, position + bytesRead, dst.writableBytes());
+            int read = dst.writeBytes(fileChannel, position + bytesRead, length);
             if (read == -1) {
                 // EOF
                 break;

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/BlockWALServiceTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/BlockWALServiceTest.java
@@ -55,6 +55,7 @@ import static com.automq.stream.s3.wal.BlockWALService.WAL_HEADER_TOTAL_CAPACITY
 import static com.automq.stream.s3.wal.WriteAheadLog.AppendResult;
 import static com.automq.stream.s3.wal.WriteAheadLog.OverCapacityException;
 import static com.automq.stream.s3.wal.WriteAheadLog.RecoverResult;
+import static com.automq.stream.s3.wal.util.WALChannelTest.TEST_BLOCK_DEVICE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -64,7 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag("S3Unit")
 class BlockWALServiceTest {
 
-    static final String TEST_BLOCK_DEVICE = System.getenv("WAL_TEST_BLOCK_DEVICE");
+    static final String TEST_BLOCK_DEVICE = System.getenv(TEST_BLOCK_DEVICE_KEY);
 
     private static void testSingleThreadAppendBasic0(boolean mergeWrite,
         boolean directIO) throws IOException, OverCapacityException {

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannelTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/util/WALBlockDeviceChannelTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import static com.automq.stream.s3.wal.util.WALChannelTest.TEST_BLOCK_DEVICE_KEY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnabledOnOs(OS.LINUX)
 public class WALBlockDeviceChannelTest {
 
-    static final String TEST_BLOCK_DEVICE = System.getenv("WAL_TEST_BLOCK_DEVICE");
+    static final String TEST_BLOCK_DEVICE = System.getenv(TEST_BLOCK_DEVICE_KEY);
 
     private String getTestPath() {
         return Optional.ofNullable(TEST_BLOCK_DEVICE).orElse(TestUtils.tempFilePath());

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/util/WALChannelTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/util/WALChannelTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("S3Unit")
-class WALChannelTest {
+public class WALChannelTest {
     public static final String TEST_BLOCK_DEVICE_KEY = "WAL_TEST_BLOCK_DEVICE";
 
     WALChannel walChannel;

--- a/s3stream/src/test/java/com/automq/stream/s3/wal/util/WALChannelTest.java
+++ b/s3stream/src/test/java/com/automq/stream/s3/wal/util/WALChannelTest.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.Test;
 
 @Tag("S3Unit")
 class WALChannelTest {
+    public static final String TEST_BLOCK_DEVICE_KEY = "WAL_TEST_BLOCK_DEVICE";
+
     WALChannel walChannel;
 
     @BeforeEach


### PR DESCRIPTION
resolve https://github.com/AutoMQ/automq-for-kafka/issues/573

On AWS EBS gp3 (3000 IOPS, 125 MB/s):
Recover 65536 messages (16 KiB each, 1 GiB in total) cost 92.7s -> 15.3s
Recover 65536 messages (4 KiB each, 256 MiB in total) cost 65.8s -> 2.5s